### PR TITLE
Fix missing consumption of params in UniReqPost

### DIFF
--- a/events_test.go
+++ b/events_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/unifi-poller/unifi"
+	"github.com/unpoller/unifi"
 )
 
 func TestIPGeoUnmarshalJSON(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/unifi-poller/unifi"
+	"github.com/unpoller/unifi"
 )
 
 func TestFlexInt(t *testing.T) {

--- a/unifi.go
+++ b/unifi.go
@@ -290,7 +290,7 @@ func (u *Unifi) UniReqPut(apiPath string, params string) (*http.Request, error) 
 func (u *Unifi) UniReqPost(apiPath string, params string) (*http.Request, error) {
 	apiPath = u.path(apiPath)
 
-	req, err := http.NewRequest(http.MethodPost, u.URL+apiPath, bytes.NewBufferString("")) //nolint:noctx
+	req, err := http.NewRequest(http.MethodPost, u.URL+apiPath, bytes.NewBufferString(params)) //nolint:noctx
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}


### PR DESCRIPTION
Fix missing params consumption that didn't get put back after a some testing the logout api path.