### PR TITLE
Add fixed IP information to User

### DIFF
--- a/users.go
+++ b/users.go
@@ -68,4 +68,6 @@ type User struct {
 	Blocked             FlexBool `json:"blocked,omitempty"`
 	DevIDOverride       FlexInt  `json:"dev_id_override,omitempty"`
 	FingerprintOverride FlexBool `json:"fingerprint_override,omitempty"`
+	UseFixedIp          FlexBool `json:"use_fixedip,omitempty"`
+	FixedIp             string   `json:"fixed_ip,omitempty"`
 }


### PR DESCRIPTION
The users data can include fixed IP information if it has been specified in the controller. I have added it to the `users.go` file.