### PR TITLE
Fix JSON generation in events.go

### DIFF
--- a/events.go
+++ b/events.go
@@ -46,7 +46,7 @@ func (u *Unifi) GetSiteEvents(site *Site, hours time.Duration) ([]*Event, error)
 
 	var (
 		path   = fmt.Sprintf(APIEventPath, site.Name)
-		params = fmt.Sprintf(`{"_limit":%d,"within":%d,"_sort":"-time"}}`,
+		params = fmt.Sprintf(`{"_limit":%d,"within":%d,"_sort":"-time"}`,
 			eventLimit, int(hours.Round(time.Hour).Hours()))
 		event struct {
 			Data events `json:"data"`


### PR DESCRIPTION
Got the hint to look at this via https://github.com/unpoller/unpoller/issues/412

I tested the fix (7.2 and 7.3 controller) and it worked for me. Although given that this file hasn't changed in 2 years, I wonder whether it would break really old unifi installs. Not sure.