### PR TITLE
[testing] Mocking rig to fuzz and get generated data based on our struct types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 *.swp
+.vscode/

--- a/alarms.go
+++ b/alarms.go
@@ -8,44 +8,44 @@ import (
 
 type Alarm struct {
 	Archived              FlexBool  `json:"archived"`
-	DestPort              int       `json:"dest_port"`
-	SrcPort               int       `json:"src_port"`
+	DestPort              int       `json:"dest_port" fake:"{port}"`
+	SrcPort               int       `json:"src_port" fake:"{port}"`
 	FlowID                int64     `json:"flow_id"`
 	InnerAlertGID         int64     `json:"inner_alert_gid"`
 	InnerAlertRev         int64     `json:"inner_alert_rev"`
 	InnerAlertSeverity    int64     `json:"inner_alert_severity"`
 	InnerAlertSignatureID int64     `json:"inner_alert_signature_id"`
-	Time                  int64     `json:"time"`
-	Timestamp             int64     `json:"timestamp"`
+	Time                  int64     `json:"time" fake:"{timestamp}"`
+	Timestamp             int64     `json:"timestamp" fake:"{timestamp}"`
 	Datetime              time.Time `json:"datetime"`
 	HandledTime           time.Time `json:"handled_time,omitempty"`
 	AppProto              string    `json:"app_proto,omitempty"`
 	Catname               string    `json:"catname"`
-	DestIP                string    `json:"dest_ip"`
-	DstMAC                string    `json:"dst_mac"`
+	DestIP                string    `json:"dest_ip" fake:"{ipv4address}"`
+	DstMAC                string    `json:"dst_mac" fake:"{macaddress}"`
 	DstIPASN              string    `json:"dstipASN,omitempty"`
 	DstIPCountry          string    `json:"dstipCountry,omitempty"`
 	EventType             string    `json:"event_type"`
 	HandledAdminID        string    `json:"handled_admin_id,omitempty"`
 	Host                  string    `json:"host"`
-	ID                    string    `json:"_id"`
-	InIface               string    `json:"in_iface"`
+	ID                    string    `json:"_id" fake:"{uuid}"`
+	InIface               string    `json:"in_iface" fake:"{randomstring:[eth0,eth1,lan1,wan1,wan2]}"`
 	InnerAlertAction      string    `json:"inner_alert_action"`
 	InnerAlertCategory    string    `json:"inner_alert_category"`
 	InnerAlertSignature   string    `json:"inner_alert_signature"`
 	Key                   string    `json:"key"`
-	Msg                   string    `json:"msg"`
+	Msg                   string    `json:"msg" fake:"{sentence:5}"`
 	Proto                 string    `json:"proto"`
-	SiteID                string    `json:"site_id"`
+	SiteID                string    `json:"site_id" fake:"{uuid}"`
 	SiteName              string    `json:"-"`
 	SourceName            string    `json:"-"`
-	SrcIP                 string    `json:"src_ip"`
+	SrcIP                 string    `json:"src_ip" fake:"{ipv4address}"`
 	SrcIPASN              string    `json:"srcipASN,omitempty"`
 	SrcIPCountry          string    `json:"srcipCountry,omitempty"`
-	SrcMAC                string    `json:"src_mac"`
+	SrcMAC                string    `json:"src_mac" fake:"{macaddress}"`
 	Subsystem             string    `json:"subsystem"`
 	UniqueAlertID         string    `json:"unique_alertid"`
-	USGIP                 string    `json:"usgip"`
+	USGIP                 string    `json:"usgip" fake:"{ipv4address}"`
 	USGIPASN              string    `json:"usgipASN"`
 	USGIPCountry          string    `json:"usgipCountry"`
 	TxID                  FlexInt   `json:"tx_id,omitempty"`

--- a/anomalies.go
+++ b/anomalies.go
@@ -11,8 +11,8 @@ import (
 // anomaly is the type UniFi returns, but not the type this library returns.
 type anomaly struct {
 	Anomaly    string  `json:"anomaly"`
-	MAC        string  `json:"mac"`
-	Timestamps []int64 `json:"timestamps"`
+	MAC        string  `json:"mac" fake:"{macaddress}"`
+	Timestamps []int64 `json:"timestamps" fake:"{timestamps}"`
 }
 
 // Anomaly is the reformatted data type that this library returns.
@@ -21,7 +21,7 @@ type Anomaly struct {
 	SourceName string
 	SiteName   string
 	Anomaly    string
-	DeviceMAC  string
+	DeviceMAC  string `fake:"{macaddress}"`
 	//	DeviceName string // we do not have this....
 }
 

--- a/clients.go
+++ b/clients.go
@@ -67,11 +67,11 @@ func (u *Unifi) GetClientsDPI(sites []*Site) ([]*DPITable, error) {
 type Client struct {
 	SourceName       string   `json:"-"`
 	Anomalies        FlexInt  `json:"anomalies,omitempty"`
-	ApMac            string   `json:"ap_mac"`
+	ApMac            string   `json:"ap_mac" fake:"{macaddress}"`
 	ApName           string   `json:"-"`
 	AssocTime        FlexInt  `json:"assoc_time"`
 	Blocked          bool     `json:"blocked,omitempty"`
-	Bssid            string   `json:"bssid"`
+	Bssid            string   `json:"bssid" fake:"{macaddress}"`
 	BytesR           FlexInt  `json:"bytes-r"`
 	Ccq              FlexInt  `json:"ccq"`
 	Channel          FlexInt  `json:"channel"`
@@ -81,14 +81,14 @@ type Client struct {
 	DevVendor        FlexInt  `json:"dev_vendor,omitempty"`
 	DhcpendTime      FlexInt  `json:"dhcpend_time,omitempty"`
 	Satisfaction     FlexInt  `json:"satisfaction,omitempty"`
-	Essid            string   `json:"essid"`
+	Essid            string   `json:"essid" fake:"{macaddress}"`
 	FirstSeen        FlexInt  `json:"first_seen"`
-	FixedIP          string   `json:"fixed_ip"`
-	GwMac            string   `json:"gw_mac"`
+	FixedIP          string   `json:"fixed_ip" fake:"{ipv4address}"`
+	GwMac            string   `json:"gw_mac" fake:"{macaddress}"`
 	GwName           string   `json:"-"`
 	Hostname         string   `json:"hostname"`
-	ID               string   `json:"_id"`
-	IP               string   `json:"ip"`
+	ID               string   `json:"_id" fake:"{uuid}"`
+	IP               string   `json:"ip" fake:"{ipv4address}"`
 	IdleTime         FlexInt  `json:"idle_time"`
 	Is11R            FlexBool `json:"is_11r"`
 	IsGuest          FlexBool `json:"is_guest"`
@@ -101,12 +101,12 @@ type Client struct {
 	LastSeenByUGW    FlexInt  `json:"_last_seen_by_ugw"`
 	LastSeenByUSW    FlexInt  `json:"_last_seen_by_usw"`
 	LatestAssocTime  FlexInt  `json:"latest_assoc_time"`
-	Mac              string   `json:"mac"`
+	Mac              string   `json:"mac" fake:"{macaddress}"`
 	Name             string   `json:"name"`
 	Network          string   `json:"network"`
-	NetworkID        string   `json:"network_id"`
+	NetworkID        string   `json:"network_id" fake:"{uuid}"`
 	Noise            FlexInt  `json:"noise"`
-	Note             string   `json:"note"`
+	Note             string   `json:"note" fake:"{sentence 20}"`
 	Noted            FlexBool `json:"noted"`
 	OsClass          FlexInt  `json:"os_class"`
 	OsName           FlexInt  `json:"os_name"`
@@ -124,10 +124,10 @@ type Client struct {
 	RxPackets        FlexInt  `json:"rx_packets"`
 	RxRate           FlexInt  `json:"rx_rate"`
 	Signal           FlexInt  `json:"signal"`
-	SiteID           string   `json:"site_id"`
+	SiteID           string   `json:"site_id" fake:"{uuid}"`
 	SiteName         string   `json:"-"`
 	SwDepth          int      `json:"sw_depth"`
-	SwMac            string   `json:"sw_mac"`
+	SwMac            string   `json:"sw_mac" fake:"{macaddress}"`
 	SwName           string   `json:"-"`
 	SwPort           FlexInt  `json:"sw_port"`
 	TxBytes          FlexInt  `json:"tx_bytes"`
@@ -141,8 +141,8 @@ type Client struct {
 	UptimeByUGW      FlexInt  `json:"_uptime_by_ugw"`
 	UptimeByUSW      FlexInt  `json:"_uptime_by_usw"`
 	UseFixedIP       FlexBool `json:"use_fixedip"`
-	UserGroupID      string   `json:"usergroup_id"`
-	UserID           string   `json:"user_id"`
+	UserGroupID      string   `json:"usergroup_id" fake:"{uuid}"`
+	UserID           string   `json:"user_id" fake:"{uuid}"`
 	Vlan             FlexInt  `json:"vlan"`
 	WifiTxAttempts   FlexInt  `json:"wifi_tx_attempts"`
 	WiredRxBytes     FlexInt  `json:"wired-rx_bytes"`

--- a/devmgr.go
+++ b/devmgr.go
@@ -27,9 +27,9 @@ const (
 // devMgrCmd is the type marshalled and sent to APIDevMgrPath.
 type devMgrCmd struct {
 	Cmd    string `json:"cmd"`                  // Required.
-	Mac    string `json:"mac"`                  // Device MAC (required for most, but not all).
-	URL    string `json:"url,omitempty"`        // External Upgrade only.
-	Inform string `json:"inform_url,omitempty"` // Migration only.
+	Mac    string `json:"mac" fake:"{macaddress}"`                  // Device MAC (required for most, but not all).
+	URL    string `json:"url,omitempty" fake:"{url}"`        // External Upgrade only.
+	Inform string `json:"inform_url,omitempty" fake:"{url}"` // Migration only.
 	Port   int    `json:"port_idx,omitempty"`   // Power Cycle only.
 }
 

--- a/devmgr.go
+++ b/devmgr.go
@@ -26,11 +26,11 @@ const (
 
 // devMgrCmd is the type marshalled and sent to APIDevMgrPath.
 type devMgrCmd struct {
-	Cmd    string `json:"cmd"`                  // Required.
-	Mac    string `json:"mac" fake:"{macaddress}"`                  // Device MAC (required for most, but not all).
+	Cmd    string `json:"cmd"`                               // Required.
+	Mac    string `json:"mac" fake:"{macaddress}"`           // Device MAC (required for most, but not all).
 	URL    string `json:"url,omitempty" fake:"{url}"`        // External Upgrade only.
 	Inform string `json:"inform_url,omitempty" fake:"{url}"` // Migration only.
-	Port   int    `json:"port_idx,omitempty"`   // Power Cycle only.
+	Port   int    `json:"port_idx,omitempty"`                // Power Cycle only.
 }
 
 // devMgrCommandReply is for commands with a return value.

--- a/dpi.go
+++ b/dpi.go
@@ -7,9 +7,9 @@ type DPITable struct {
 	SourceName  string    `json:"-"`
 	SiteName    string    `json:"-"`
 	Name        string    `json:"-"`
-	MAC         string    `json:"mac"`
-	ByCat       []DPIData `json:"by_cat"`
-	ByApp       []DPIData `json:"by_app"`
+	MAC         string    `json:"mac" fake:"{macaddress}"`
+	ByCat       []DPIData `json:"by_cat" fakesize:"5"`
+	ByApp       []DPIData `json:"by_app" fakesize:"5"`
 	LastUpdated FlexInt   `json:"last_updated"`
 }
 
@@ -21,13 +21,13 @@ type DPIData struct {
 	TxBytes      FlexInt      `json:"tx_bytes"`
 	RxPackets    FlexInt      `json:"rx_packets"`
 	TxPackets    FlexInt      `json:"tx_packets"`
-	Clients      []*DPIClient `json:"clients,omitempty"`
+	Clients      []*DPIClient `json:"clients,omitempty" fakesize:"5"`
 	KnownClients FlexInt      `json:"known_clients,omitempty"`
 }
 
 // DPIClient data is sometimes included in ByApp output.
 type DPIClient struct {
-	Mac       string  `json:"mac"`
+	Mac       string  `json:"mac" fake:"{macaddress}"`
 	RxBytes   FlexInt `json:"rx_bytes"`
 	TxBytes   FlexInt `json:"tx_bytes"`
 	RxPackets FlexInt `json:"rx_packets"`

--- a/events.go
+++ b/events.go
@@ -73,8 +73,8 @@ func (u *Unifi) GetSiteEvents(site *Site, hours time.Duration) ([]*Event, error)
 // API Path: /api/s/default/stat/event.
 type Event struct {
 	IsAdmin               FlexBool  `json:"is_admin"`
-	DestPort              int       `json:"dest_port"`
-	SrcPort               int       `json:"src_port"`
+	DestPort              int       `json:"dest_port" fake:"{port}"`
+	SrcPort               int       `json:"src_port" fake:"{port}"`
 	Bytes                 FlexInt   `json:"bytes"`
 	Duration              FlexInt   `json:"duration"`
 	FlowID                FlexInt   `json:"flow_id"`
@@ -85,8 +85,8 @@ type Event struct {
 	Channel               FlexInt   `json:"channel"`
 	ChannelFrom           FlexInt   `json:"channel_from"`
 	ChannelTo             FlexInt   `json:"channel_to"`
-	Time                  int64     `json:"time"`
-	Timestamp             int64     `json:"timestamp"`
+	Time                  int64     `json:"time" fake:"{timestamp}"`
+	Timestamp             int64     `json:"timestamp" fake:"{timestamp}"`
 	Datetime              time.Time `json:"datetime"`
 	Admin                 string    `json:"admin"`
 	Ap                    string    `json:"ap"`
@@ -95,43 +95,43 @@ type Event struct {
 	ApTo                  string    `json:"ap_to"`
 	AppProto              string    `json:"app_proto"`
 	Catname               string    `json:"catname"`
-	DestIP                string    `json:"dest_ip"`
-	DstMAC                string    `json:"dst_mac"`
+	DestIP                string    `json:"dest_ip" fake:"{ipv4address}"`
+	DstMAC                string    `json:"dst_mac" fake:"{macaddress}"`
 	EventType             string    `json:"event_type"`
 	Guest                 string    `json:"guest"`
 	Gw                    string    `json:"gw"`
 	GwName                string    `json:"gw_name"`
 	Host                  string    `json:"host"`
 	Hostname              string    `json:"hostname"`
-	ID                    string    `json:"_id"`
-	IP                    string    `json:"ip"`
+	ID                    string    `json:"_id" fake:"{uuid}"`
+	IP                    string    `json:"ip" fake:"{ipv4address}"`
 	InIface               string    `json:"in_iface"`
 	InnerAlertAction      string    `json:"inner_alert_action"`
 	InnerAlertCategory    string    `json:"inner_alert_category"`
 	InnerAlertSignature   string    `json:"inner_alert_signature"`
-	Key                   string    `json:"key"`
-	Msg                   string    `json:"msg"`
+	Key                   string    `json:"key" fake:"{uuid}"`
+	Msg                   string    `json:"msg" fake:"{sentence:20}"`
 	Network               string    `json:"network"`
 	Proto                 string    `json:"proto"`
 	Radio                 string    `json:"radio"`
 	RadioFrom             string    `json:"radio_from"`
 	RadioTo               string    `json:"radio_to"`
-	SiteID                string    `json:"site_id"`
+	SiteID                string    `json:"site_id" fake:"{}"`
 	SiteName              string    `json:"-"`
 	SourceName            string    `json:"-"`
-	SrcIP                 string    `json:"src_ip"`
-	SrcMAC                string    `json:"src_mac"`
-	SrcIPASN              string    `json:"srcipASN"`
-	SrcIPCountry          string    `json:"srcipCountry"`
-	SSID                  string    `json:"ssid"`
+	SrcIP                 string    `json:"src_ip" fake:"{ipv4address}"`
+	SrcMAC                string    `json:"src_mac" fake:"{macaddress}"`
+	SrcIPASN              string    `json:"srcipASN" fake:"{address}"`
+	SrcIPCountry          string    `json:"srcipCountry" fake:"{country}"`
+	SSID                  string    `json:"ssid" fake:"{macaddress}"`
 	Subsystem             string    `json:"subsystem"`
 	Sw                    string    `json:"sw"`
 	SwName                string    `json:"sw_name"`
 	UniqueAlertID         string    `json:"unique_alertid"`
 	User                  string    `json:"user"`
-	USGIP                 string    `json:"usgip"`
-	USGIPASN              string    `json:"usgipASN"`
-	USGIPCountry          string    `json:"usgipCountry"`
+	USGIP                 string    `json:"usgip" fake:"{ipv4address}"`
+	USGIPASN              string    `json:"usgipASN" fake:"{address}"`
+	USGIPCountry          string    `json:"usgipCountry" fake:"{country}"`
 	DestIPGeo             IPGeo     `json:"dstipGeo"`
 	SourceIPGeo           IPGeo     `json:"srcipGeo"`
 	USGIPGeo              IPGeo     `json:"usgipGeo"`
@@ -140,14 +140,14 @@ type Event struct {
 // IPGeo is part of the UniFi Event data. Each event may have up to three of these.
 // One for source, one for dest and one for the USG location.
 type IPGeo struct {
-	Asn           int64   `json:"asn"`
-	Latitude      float64 `json:"latitude"`
-	Longitude     float64 `json:"longitude"`
-	City          string  `json:"city"`
+	Asn           int64   `json:"asn" fake:"{address}"`
+	Latitude      float64 `json:"latitude" fake:"{latitude}"`
+	Longitude     float64 `json:"longitude" fake:"{longitude}"`
+	City          string  `json:"city" fake:"{city}"`
 	ContinentCode string  `json:"continent_code"`
-	CountryCode   string  `json:"country_code"`
-	CountryName   string  `json:"country_name"`
-	Organization  string  `json:"organization"`
+	CountryCode   string  `json:"country_code" fake:"{countryabr}"`
+	CountryName   string  `json:"country_name" fake:"{country}"`
+	Organization  string  `json:"organization" fake:"{company}"`
 }
 
 // Events satisfied the sort.Interface.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/unpoller/unifi
 go 1.19
 
 require (
+	github.com/brianvoe/gofakeit/v6 v6.23.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/net v0.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/brianvoe/gofakeit/v6 v6.23.0 h1:pgVhyWpYq4e0GEVCh2gdZnS/nBX+8SnyTBliHg5xjks=
+github.com/brianvoe/gofakeit/v6 v6.23.0/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ids.go
+++ b/ids.go
@@ -10,44 +10,44 @@ import (
 // IDS holds an Intrusion Prevention System Event.
 type IDS struct {
 	Archived              FlexBool  `json:"archived"`
-	DestPort              int       `json:"dest_port,omitempty"`
-	SrcPort               int       `json:"src_port,omitempty"`
-	FlowID                int64     `json:"flow_id"`
+	DestPort              int       `json:"dest_port,omitempty" fake:"{port}"`
+	SrcPort               int       `json:"src_port,omitempty" fake:"{port}"`
+	FlowID                int64     `json:"flow_id" fake:"{uuid}"`
 	InnerAlertRev         int64     `json:"inner_alert_rev"`
 	InnerAlertSeverity    int64     `json:"inner_alert_severity"`
 	InnerAlertGID         int64     `json:"inner_alert_gid"`
 	InnerAlertSignatureID int64     `json:"inner_alert_signature_id"`
-	Time                  int64     `json:"time"`
-	Timestamp             int64     `json:"timestamp"`
+	Time                  int64     `json:"time" fake:"{timestamp}"`
+	Timestamp             int64     `json:"timestamp" fake:"{timestamp}"`
 	Datetime              time.Time `json:"datetime"`
 	AppProto              string    `json:"app_proto,omitempty"`
 	Catname               string    `json:"catname"`
-	DestIP                string    `json:"dest_ip"`
-	DstMAC                string    `json:"dst_mac"`
-	DstIPASN              string    `json:"dstipASN"`
-	DstIPCountry          string    `json:"dstipCountry"`
+	DestIP                string    `json:"dest_ip" fake:"{ipv4address}"`
+	DstMAC                string    `json:"dst_mac" fake:"{macaddress}"`
+	DstIPASN              string    `json:"dstipASN" fake:"{address}"`
+	DstIPCountry          string    `json:"dstipCountry" fake:"{country}"`
 	EventType             string    `json:"event_type"`
 	Host                  string    `json:"host"`
-	ID                    string    `json:"_id"`
+	ID                    string    `json:"_id" fake:"{uuid}"`
 	InIface               string    `json:"in_iface"`
 	InnerAlertAction      string    `json:"inner_alert_action"`
 	InnerAlertCategory    string    `json:"inner_alert_category"`
 	InnerAlertSignature   string    `json:"inner_alert_signature"`
-	Key                   string    `json:"key"`
-	Msg                   string    `json:"msg"`
+	Key                   string    `json:"key" fake:"{uuid}"`
+	Msg                   string    `json:"msg" fake:"{sentence:20}"`
 	Proto                 string    `json:"proto"`
-	SiteID                string    `json:"site_id"`
+	SiteID                string    `json:"site_id" fake:"{uuid}"`
 	SiteName              string    `json:"-"`
 	SourceName            string    `json:"-"`
-	SrcIP                 string    `json:"src_ip"`
-	SrcIPASN              string    `json:"srcipASN"`
-	SrcIPCountry          string    `json:"srcipCountry"`
-	SrcMAC                string    `json:"src_mac"`
+	SrcIP                 string    `json:"src_ip" fake:"{ipv4address}"`
+	SrcIPASN              string    `json:"srcipASN" fake:"{address}"`
+	SrcIPCountry          string    `json:"srcipCountry" fake:"{country}"`
+	SrcMAC                string    `json:"src_mac" fake:"{macaddress}"`
 	Subsystem             string    `json:"subsystem"`
-	UniqueAlertID         string    `json:"unique_alertid"`
-	USGIP                 string    `json:"usgip"`
-	USGIPASN              string    `json:"usgipASN"`
-	USGIPCountry          string    `json:"usgipCountry"`
+	UniqueAlertID         string    `json:"unique_alertid" fake:"{uuid}"`
+	USGIP                 string    `json:"usgip" fake:"{ipv4address}"`
+	USGIPASN              string    `json:"usgipASN" fake:"{address}"`
+	USGIPCountry          string    `json:"usgipCountry" fake:"{country}"`
 	DestIPGeo             IPGeo     `json:"dstipGeo"`
 	SourceIPGeo           IPGeo     `json:"srcipGeo"`
 	USGIPGeo              IPGeo     `json:"usgipGeo"`
@@ -71,7 +71,7 @@ func (u *Unifi) GetIDS(sites []*Site, timeRange ...time.Time) ([]*IDS, error) {
 	return data, nil
 }
 
-// GetIDSSite retreives the Intrusion Detection System Data for a single Site.
+// GetIDSSite retrieves the Intrusion Detection System Data for a single Site.
 // timeRange may have a length of 0, 1 or 2. The first time is Start, the second is End.
 // Events between start and end are returned. End defaults to time.Now().
 func (u *Unifi) GetIDSSite(site *Site, timeRange ...time.Time) ([]*IDS, error) {

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -369,3 +369,19 @@ func (m *MockUnifi) Logout() error {
 func (m *MockUnifi) GetServerData() error {
 	return nil
 }
+
+// GetUsers returns a response full of clients that connected to the UDM within the provided amount of time
+// using the insight historical connection data set.
+func (m *MockUnifi) GetUsers(sites []*unifi.Site, hours int) ([]*unifi.User, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.User, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.User
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -1,0 +1,362 @@
+package mocks
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/unpoller/unifi"
+)
+
+type MockUnifi struct {
+	faker *gofakeit.Faker
+}
+
+func fakeSeedValue() int64 {
+	seedVal := os.Getenv("UNPOLLER_FAKE_GEN_SEED")
+	if seedVal != "" {
+		if seed, err := strconv.ParseInt(seedVal, 10, 64); err != nil {
+			return seed
+		}
+	}
+	return 0
+}
+
+func NewMockUnifi() *MockUnifi {
+	faker := gofakeit.New(fakeSeedValue())
+	return &MockUnifi{
+		faker: faker,
+	}
+}
+
+// GetAlarms returns Alarms for a list of Sites.
+func (m *MockUnifi) GetAlarms(sites []*unifi.Site) ([]*unifi.Alarm, error) {
+	qty := m.faker.Rand.Intn(5)
+	alarms := make([]*unifi.Alarm, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Alarm
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return alarms, err
+		}
+		alarms[i] = &a
+	}
+	return alarms, nil
+}
+
+// GetAlarmsSite retreives the Alarms for a single Site.
+func (m *MockUnifi) GetAlarmsSite(site *unifi.Site) ([]*unifi.Alarm, error) {
+	qty := m.faker.Rand.Intn(5)
+	alarms := make([]*unifi.Alarm, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Alarm
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return alarms, err
+		}
+		alarms[i] = &a
+	}
+	return alarms, nil
+}
+
+// GetAnomalies returns Anomalies for a list of Sites.
+func (m *MockUnifi) GetAnomalies(sites []*unifi.Site, timeRange ...time.Time) ([]*unifi.Anomaly, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.Anomaly, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Anomaly
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetAnomaliesSite retreives the Anomalies for a single Site.
+func (m *MockUnifi) GetAnomaliesSite(site *unifi.Site, timeRange ...time.Time) ([]*unifi.Anomaly, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.Anomaly, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Anomaly
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetClients returns a response full of clients' data from the UniFi Controller.
+func (m *MockUnifi) GetClients(sites []*unifi.Site) ([]*unifi.Client, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.Client, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Client
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetClientsDPI garners dpi data for clients.
+func (m *MockUnifi) GetClientsDPI(sites []*unifi.Site) ([]*unifi.DPITable, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.DPITable, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.DPITable
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetDevices returns a response full of devices' data from the UniFi Controller.
+func (m *MockUnifi) GetDevices(sites []*unifi.Site) (*unifi.Devices, error) {
+	var d unifi.Devices
+	err := m.faker.Struct(&d)
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// GetUSWs returns all switches, an error, or nil if there are no switches.
+func (m *MockUnifi) GetUSWs(site *unifi.Site) ([]*unifi.USW, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.USW, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.USW
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetUAPs returns all access points, an error, or nil if there are no APs.
+func (m *MockUnifi) GetUAPs(site *unifi.Site) ([]*unifi.UAP, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.UAP, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.UAP
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetUDMs returns all dream machines, an error, or nil if there are no UDMs.
+func (m *MockUnifi) GetUDMs(site *unifi.Site) ([]*unifi.UDM, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.UDM, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.UDM
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetUXGs returns all 10Gb gateways, an error, or nil if there are no UXGs.
+func (m *MockUnifi) GetUXGs(site *unifi.Site) ([]*unifi.UXG, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.UXG, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.UXG
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetUSGs returns all 1Gb gateways, an error, or nil if there are no USGs.
+func (m *MockUnifi) GetUSGs(site *unifi.Site) ([]*unifi.USG, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.USG, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.USG
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetEvents returns a response full of UniFi Events for the last 1 hour from multiple sites.
+func (m *MockUnifi) GetEvents(sites []*unifi.Site, hours time.Duration) ([]*unifi.Event, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.Event, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Event
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetSiteEvents retrieves the last 1 hour's worth of events from a single site.
+func (m *MockUnifi) GetSiteEvents(site *unifi.Site, hours time.Duration) ([]*unifi.Event, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.Event, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Event
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetIDS returns Intrusion Detection Systems events for a list of Sites.
+// timeRange may have a length of 0, 1 or 2. The first time is Start, the second is End.
+// Events between start and end are returned. End defaults to time.Now().
+func (m *MockUnifi) GetIDS(sites []*unifi.Site, timeRange ...time.Time) ([]*unifi.IDS, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.IDS, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.IDS
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetIDSSite retrieves the Intrusion Detection System Data for a single Site.
+// timeRange may have a length of 0, 1 or 2. The first time is Start, the second is End.
+// Events between start and end are returned. End defaults to time.Now().
+func (m *MockUnifi) GetIDSSite(site *unifi.Site, timeRange ...time.Time) ([]*unifi.IDS, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.IDS, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.IDS
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetNetworks returns a response full of network data from the UniFi Controller.
+func (m *MockUnifi) GetNetworks(sites []*unifi.Site) ([]unifi.Network, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]unifi.Network, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Network
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = a
+	}
+	return results, nil
+}
+
+// GetSites returns a list of configured sites on the UniFi controller.
+func (m *MockUnifi) GetSites() ([]*unifi.Site, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.Site, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.Site
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetSiteDPI garners dpi data for sites.
+func (m *MockUnifi) GetSiteDPI(sites []*unifi.Site) ([]*unifi.DPITable, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.DPITable, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.DPITable
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetRogueAPs returns RogueAPs for a list of Sites.
+// Use GetRogueAPsSite if you want more control.
+func (m *MockUnifi) GetRogueAPs(sites []*unifi.Site) ([]*unifi.RogueAP, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.RogueAP, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.RogueAP
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// GetRogueAPsSite returns RogueAPs for a single Site.
+func (m *MockUnifi) GetRogueAPsSite(site *unifi.Site) ([]*unifi.RogueAP, error) {
+	qty := m.faker.Rand.Intn(5)
+	results := make([]*unifi.RogueAP, qty)
+	for i := 0; i < qty; i++ {
+		var a unifi.RogueAP
+		err := m.faker.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+		results[i] = &a
+	}
+	return results, nil
+}
+
+// Login is a helper method. It can be called to grab a new authentication cookie.
+func (m *MockUnifi) Login() error {
+	return nil
+}
+
+// Logout closes the current session.
+func (m *MockUnifi) Logout() error {
+	return nil
+}
+
+// GetServerData sets the controller's version and UUID. Only call this if you
+// previously called Login and suspect the controller version has changed.
+func (m *MockUnifi) GetServerData() error {
+	return nil
+}

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -11,7 +11,11 @@ import (
 
 type MockUnifi struct {
 	faker *gofakeit.Faker
+	*unifi.Config
 }
+
+// ensure MockUnifi implements the interface fully, this will fail to compile otherwise
+var _ unifi.UnifiClient = &MockUnifi{}
 
 func fakeSeedValue() int64 {
 	seedVal := os.Getenv("UNPOLLER_FAKE_GEN_SEED")
@@ -24,7 +28,12 @@ func fakeSeedValue() int64 {
 }
 
 func NewMockUnifi() *MockUnifi {
-	faker := gofakeit.New(fakeSeedValue())
+	return NewMockUnifiWithSeed(fakeSeedValue())
+
+}
+
+func NewMockUnifiWithSeed(seed int64) *MockUnifi {
+	faker := gofakeit.New(seed)
 	return &MockUnifi{
 		faker: faker,
 	}

--- a/mocks/mock_server.go
+++ b/mocks/mock_server.go
@@ -1,0 +1,127 @@
+package mocks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/unpoller/unifi"
+)
+
+type MockHTTPTestServer struct {
+	server *httptest.Server
+	mocked *MockUnifi
+}
+
+func NewMockHTTPTestServer() *MockHTTPTestServer {
+	mocked := NewMockUnifi()
+	m := &MockHTTPTestServer{mocked: mocked}
+	s := httptest.NewServer(m)
+	m.server = s
+	return m
+}
+
+func convertPathToRegexPattern(s string) string {
+	tmp := strings.ReplaceAll(strings.ReplaceAll(s, "%s", "[a-zA-Z-_,.]+"), "%d", "[0-9]+")
+	return fmt.Sprintf("(%s)?%s", unifi.APIPrefixNew, tmp)
+
+}
+
+// compile regexp matches to paths
+var (
+	apiRogueAP         = regexp.MustCompile(convertPathToRegexPattern(unifi.APIRogueAP))
+	apiStatusPath      = regexp.MustCompile(convertPathToRegexPattern(unifi.APIStatusPath))
+	apiEventPath       = regexp.MustCompile(convertPathToRegexPattern(unifi.APIEventPath))
+	apiSiteList        = regexp.MustCompile(convertPathToRegexPattern(unifi.APISiteList))
+	apiSiteDPI         = regexp.MustCompile(convertPathToRegexPattern(unifi.APISiteDPI))
+	apiClientDPI       = regexp.MustCompile(convertPathToRegexPattern(unifi.APIClientDPI))
+	apiClientPath      = regexp.MustCompile(convertPathToRegexPattern(unifi.APIClientPath))
+	apiAllUserPath     = regexp.MustCompile(convertPathToRegexPattern(unifi.APIAllUserPath))
+	apiNetworkPath     = regexp.MustCompile(convertPathToRegexPattern(unifi.APINetworkPath))
+	apiDevicePath      = regexp.MustCompile(convertPathToRegexPattern(unifi.APIDevicePath))
+	apiLoginPath       = regexp.MustCompile(convertPathToRegexPattern(unifi.APILoginPath))
+	apiLoginPathNew    = regexp.MustCompile(convertPathToRegexPattern(unifi.APILoginPathNew))
+	apiLogoutPath      = regexp.MustCompile(convertPathToRegexPattern(unifi.APILogoutPath))
+	apiEventPathIDS    = regexp.MustCompile(convertPathToRegexPattern(unifi.APIEventPathIDS))
+	apiEventPathAlarms = regexp.MustCompile(convertPathToRegexPattern(unifi.APIEventPathAlarms))
+	apiAnomaliesPath   = regexp.MustCompile(convertPathToRegexPattern(unifi.APIAnomaliesPath))
+	apiCommandPath     = regexp.MustCompile(convertPathToRegexPattern(unifi.APICommandPath))
+	apiDevMgrPath      = regexp.MustCompile(convertPathToRegexPattern(unifi.APIDevMgrPath))
+)
+
+func respondResultOrErr(w http.ResponseWriter, v any, err error) {
+	if err != nil {
+		b, _ := json.Marshal(err)
+		w.Write(b)
+		w.WriteHeader(500)
+		return
+	}
+	b, _ := json.Marshal(v)
+	w.Write(b)
+	w.WriteHeader(200)
+}
+
+func (m *MockHTTPTestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p := strings.TrimSpace(r.URL.Path)
+	switch {
+	case apiRogueAP.MatchString(p):
+		aps, err := m.mocked.GetRogueAPs(nil)
+		respondResultOrErr(w, aps, err)
+	case apiStatusPath.MatchString(p):
+		// todo
+	case apiEventPath.MatchString(p):
+		events, err := m.mocked.GetEvents(nil, time.Hour)
+		respondResultOrErr(w, events, err)
+	case apiSiteList.MatchString(p):
+		sites, err := m.mocked.GetSites()
+		respondResultOrErr(w, sites, err)
+	case apiSiteDPI.MatchString(p):
+		dpi, err := m.mocked.GetSiteDPI(nil)
+		respondResultOrErr(w, dpi, err)
+	case apiClientDPI.MatchString(p):
+		dpi, err := m.mocked.GetClientsDPI(nil)
+		respondResultOrErr(w, dpi, err)
+	case apiClientPath.MatchString(p):
+		clients, err := m.mocked.GetClients(nil)
+		respondResultOrErr(w, clients, err)
+	case apiAllUserPath.MatchString(p):
+		users, err := m.mocked.GetUsers(nil, 1)
+		respondResultOrErr(w, users, err)
+	case apiNetworkPath.MatchString(p):
+		networks, err := m.mocked.GetNetworks(nil)
+		respondResultOrErr(w, networks, err)
+	case apiDevicePath.MatchString(p):
+		devices, err := m.mocked.GetDevices(nil)
+		respondResultOrErr(w, devices, err)
+	case apiLoginPath.MatchString(p):
+		err := m.mocked.Login()
+		respondResultOrErr(w, nil, err)
+	case apiLoginPathNew.MatchString(p):
+		err := m.mocked.Login()
+		respondResultOrErr(w, nil, err)
+	case apiLogoutPath.MatchString(p):
+		err := m.mocked.Logout()
+		respondResultOrErr(w, nil, err)
+	case apiEventPathIDS.MatchString(p):
+		ids, err := m.mocked.GetIDS(nil, time.Now())
+		respondResultOrErr(w, ids, err)
+	case apiEventPathAlarms.MatchString(p):
+		alarms, err := m.mocked.GetAlarms(nil)
+		respondResultOrErr(w, alarms, err)
+	case apiAnomaliesPath.MatchString(p):
+		anomalies, err := m.mocked.GetAnomalies(nil, time.Now())
+		respondResultOrErr(w, anomalies, err)
+	case apiDevMgrPath.MatchString(p):
+		// todo
+		w.WriteHeader(501)
+	case apiCommandPath.MatchString(p):
+		// todo
+		w.WriteHeader(501)
+	default:
+		http.NotFoundHandler().ServeHTTP(w, r)
+	}
+}

--- a/mocks/mock_server.go
+++ b/mocks/mock_server.go
@@ -61,7 +61,7 @@ func respondResultOrErr(w http.ResponseWriter, v any, err error) {
 		return
 	}
 	b, _ := json.Marshal(v)
-	w.Write(b)
+	_, _ = w.Write(b)
 	w.WriteHeader(200)
 }
 

--- a/mocks/mock_server.go
+++ b/mocks/mock_server.go
@@ -56,7 +56,7 @@ var (
 func respondResultOrErr(w http.ResponseWriter, v any, err error) {
 	if err != nil {
 		b, _ := json.Marshal(err)
-		w.Write(b)
+		_, _ = w.Write(b)
 		w.WriteHeader(500)
 		return
 	}

--- a/networks.go
+++ b/networks.go
@@ -50,13 +50,13 @@ type Network struct {
 	DhcpGuardEnabled       FlexBool `json:"dhcpguard_enabled"`
 	DomainName             string   `json:"domain_name"`
 	Enabled                FlexBool `json:"enabled"`
-	ID                     string   `json:"_id"`
+	ID                     string   `json:"_id" fake:"{uuid}"`
 	IPSubnet               string   `json:"ip_subnet"`
 	IsNat                  FlexBool `json:"is_nat"`
 	Name                   string   `json:"name"`
 	Networkgroup           string   `json:"networkgroup"`
 	Purpose                string   `json:"purpose"`
-	SiteID                 string   `json:"site_id"`
+	SiteID                 string   `json:"site_id" fake:"{uuid}"`
 	Vlan                   FlexInt  `json:"vlan"`
 	VlanEnabled            FlexBool `json:"vlan_enabled"`
 }

--- a/pdu.go
+++ b/pdu.go
@@ -5,45 +5,45 @@ import "encoding/json"
 // PDU is the Smart Power PDU line of products
 type PDU struct {
 	site                     *Site
-	ID                       string           `json:"_id"`
-	AdoptIP                  string           `json:"adopt_ip"`
-	AdoptURL                 string           `json:"adopt_url"`
+	ID                       string           `json:"_id" fake:"{uuid}"`
+	AdoptIP                  string           `json:"adopt_ip" fake:"{ipv4address}"`
+	AdoptURL                 string           `json:"adopt_url" fake:"{url}"`
 	AdoptableWhenUpgraded    FlexBool         `json:"adoptable_when_upgraded"`
 	Adopted                  FlexBool         `json:"adopted"`
 	Anomalies                FlexInt          `json:"anomalies"`
-	AnonID                   string           `json:"anon_id"`
+	AnonID                   string           `json:"anon_id" fake:"{uuid}"`
 	Architecture             string           `json:"architecture"`
 	BoardRev                 FlexInt          `json:"board_rev"`
 	Bytes                    FlexInt          `json:"bytes"`
 	CfgVersion               string           `json:"cfgversion"`
 	ConfigNetwork            *ConfigNetwork   `json:"config_network"`
-	ConnectRequestIP         string           `json:"connect_request_ip"`
-	ConnectRequestPort       FlexInt          `json:"connect_request_port"`
-	ConnectedAt              FlexInt          `json:"connected_at"`
+	ConnectRequestIP         string           `json:"connect_request_ip" fake:"{ipv4address}"`
+	ConnectRequestPort       FlexInt          `json:"connect_request_port" fake:"{port}"`
+	ConnectedAt              FlexInt          `json:"connected_at" fake:"{timestamp}"`
 	ConnectionNetworkName    string           `json:"connection_network_name"`
 	Default                  FlexBool         `json:"default"`
-	DeviceID                 string           `json:"device_id"`
+	DeviceID                 string           `json:"device_id" fake:"{uuid}"`
 	DiscoveredVia            string           `json:"discovered_via"`
 	DisplayableVersion       string           `json:"displayable_version"`
 	Dot1xPortCtrlEnabled     FlexBool         `json:"dot1x_portctrl_enabled"`
-	DownlinkTable            []*DownlinkTable `json:"downlink_table"`
-	EthernetTable            []*EthernetTable `json:"ethernet_table"`
+	DownlinkTable            []*DownlinkTable `json:"downlink_table" fakesize:"5"`
+	EthernetTable            []*EthernetTable `json:"ethernet_table" fakesize:"5"`
 	FlowctrlEnabled          FlexBool         `json:"flowctrl_enabled"`
 	FwCaps                   FlexInt          `json:"fw_caps"`
-	GatewayMac               string           `json:"gateway_mac"`
+	GatewayMac               string           `json:"gateway_mac" fake:"{macaddress}"`
 	GuestNumSta              FlexInt          `json:"guest-num_sta"`
 	HasFan                   FlexBool         `json:"has_fan"`
 	HasTemperature           FlexBool         `json:"has_temperature"`
 	HashID                   string           `json:"hash_id"`
 	HwCaps                   FlexInt          `json:"hw_caps"`
-	InformIP                 string           `json:"inform_ip"`
-	InformURL                string           `json:"inform_url"`
+	InformIP                 string           `json:"inform_ip" fake:"{ipv4address}"`
+	InformURL                string           `json:"inform_url" fake:"{url}"`
 	Internet                 FlexBool         `json:"internet"`
-	IP                       string           `json:"ip"`
+	IP                       string           `json:"ip" fake:"{ipv4address}"`
 	JumboframeEnabled        FlexBool         `json:"jumboframe_enabled"`
 	KernelVersion            string           `json:"kernel_version"`
 	KnownCfgVersion          string           `json:"known_cfgversion"`
-	LastSeen                 FlexInt          `json:"last_seen"`
+	LastSeen                 FlexInt          `json:"last_seen" fake:"{timestamp}"`
 	LastUplink               Uplink           `json:"last_uplink"`
 	LcmBrightness            FlexInt          `json:"lcm_brightness"`
 	LcmBrightnessOverride    FlexBool         `json:"lcm_brightness_override"`
@@ -52,7 +52,7 @@ type PDU struct {
 	LcmNightModeEnds         string           `json:"lcm_night_mode_ends"`
 	LicenseState             string           `json:"license_state"`
 	Locating                 FlexBool         `json:"locating"`
-	Mac                      string           `json:"mac"`
+	Mac                      string           `json:"mac" fake:"{macaddress}"`
 	ManufacturerID           FlexInt          `json:"manufacturer_id"`
 	MinIfnromIntervalSeconds FlexInt          `json:"min_inform_interval_seconds"`
 	Model                    string           `json:"model"`
@@ -65,26 +65,26 @@ type PDU struct {
 	OutletACPowerBudget      FlexInt          `json:"outlet_ac_power_budget"`
 	OutletACPowerConsumption FlexInt          `json:"outlet_ac_power_consumption"`
 	OutletEnabled            FlexBool         `json:"outlet_enabled"`
-	OutletOverrides          []OutletOverride `json:"outlet_overrides"`
-	OutletTable              []OutletTable    `json:"outlet_table"`
+	OutletOverrides          []OutletOverride `json:"outlet_overrides" fakesize:"5"`
+	OutletTable              []OutletTable    `json:"outlet_table" fakesize:"5"`
 	Overheating              FlexBool         `json:"overheating"`
-	PortTable                []Port           `json:"port_table"`
+	PortTable                []Port           `json:"port_table" fakesize:"5"`
 	PowerSource              FlexInt          `json:"power_source"`
 	PowerSourceCtrlEnabled   FlexBool         `json:"power_source_ctrl_enabled"`
 	PrevNonBusyState         FlexInt          `json:"prev_non_busy_state"`
-	ProvisionedAt            FlexInt          `json:"provisioned_at"`
+	ProvisionedAt            FlexInt          `json:"provisioned_at" fake:"{timestamp}"`
 	RequiredVersion          string           `json:"required_version"`
 	RollUpgrade              FlexBool         `json:"rollupgrade"`
 	RxBytes                  FlexInt          `json:"rx_bytes"`
 	Satisfaction             FlexInt          `json:"satisfaction"`
 	Serial                   string           `json:"serial"`
-	SetupID                  string           `json:"setup_id"`
-	SiteID                   string           `json:"site_id"`
+	SetupID                  string           `json:"setup_id" fake:"{uuid}"`
+	SiteID                   string           `json:"site_id" fake:"{uuid}"`
 	SiteName                 string           `json:"site_name"`
 	SourceName               string           `json:"source_name"`
-	StartConnectedMillis     FlexInt          `json:"start_connected_millis"`
-	StartDisconnectedMillis  FlexInt          `json:"start_disconnected_millis"`
-	StartupTimestamp         FlexInt          `json:"startup_timestamp"`
+	StartConnectedMillis     FlexInt          `json:"start_connected_millis" fake:"{timestamp}"`
+	StartDisconnectedMillis  FlexInt          `json:"start_disconnected_millis" fake:"{timestamp}"`
+	StartupTimestamp         FlexInt          `json:"startup_timestamp" fake:"{timestamp}"`
 	Stat                     PDUStat          `json:"stat"`
 	State                    FlexInt          `json:"state"`
 	StpPriority              FlexInt          `json:"stp_priority"`
@@ -103,7 +103,7 @@ type PDU struct {
 	Upgradeable              FlexBool         `json:"upgradable"`
 	Uplink                   Uplink           `json:"uplink"`
 	UplinkDepth              FlexBool         `json:"uplink_depth"`
-	Uptime                   FlexInt          `json:"uptime"`
+	Uptime                   FlexInt          `json:"uptime" fake:"{timestamp}"`
 	UserNumSta               FlexInt          `json:"user-num_sta"`
 	Version                  string           `json:"version"`
 }

--- a/site.go
+++ b/site.go
@@ -71,9 +71,9 @@ func (u *Unifi) GetSiteDPI(sites []*Site) ([]*DPITable, error) {
 type Site struct {
 	controller   *Unifi
 	SourceName   string   `json:"-"`
-	ID           string   `json:"_id"`
+	ID           string   `json:"_id" fake:"{uuid}"`
 	Name         string   `json:"name"`
-	Desc         string   `json:"desc"`
+	Desc         string   `json:"desc" fake:"{sentence:20}"`
 	SiteName     string   `json:"-"`
 	AttrHiddenID string   `json:"attr_hidden_id"`
 	AttrNoDelete FlexBool `json:"attr_no_delete"`
@@ -91,12 +91,12 @@ type Site struct {
 		NumDisconnected FlexInt  `json:"num_disconnected,omitempty"`
 		NumPending      FlexInt  `json:"num_pending,omitempty"`
 		NumGw           FlexInt  `json:"num_gw,omitempty"`
-		WanIP           string   `json:"wan_ip,omitempty"`
-		Gateways        []string `json:"gateways,omitempty"`
+		WanIP           string   `json:"wan_ip,omitempty" fake:"{ipv4address}"`
+		Gateways        []string `json:"gateways,omitempty" fakesize:"5"`
 		Netmask         string   `json:"netmask,omitempty"`
-		Nameservers     []string `json:"nameservers,omitempty"`
+		Nameservers     []string `json:"nameservers,omitempty" fakesize:"5"`
 		NumSta          FlexInt  `json:"num_sta,omitempty"`
-		GwMac           string   `json:"gw_mac,omitempty"`
+		GwMac           string   `json:"gw_mac,omitempty" fake:"{macaddress}"`
 		GwName          string   `json:"gw_name,omitempty"`
 		GwSystemStats   struct {
 			CPU    FlexInt `json:"cpu"`
@@ -122,6 +122,6 @@ type Site struct {
 		RemoteUserRxPackets   FlexInt  `json:"remote_user_rx_packets,omitempty"`
 		RemoteUserTxPackets   FlexInt  `json:"remote_user_tx_packets,omitempty"`
 		SiteToSiteEnabled     FlexBool `json:"site_to_site_enabled,omitempty"`
-	} `json:"health"`
+	} `json:"health" fakesize:"5"`
 	NumNewAlarms FlexInt `json:"num_new_alarms"`
 }

--- a/types.go
+++ b/types.go
@@ -225,6 +225,9 @@ type Unifi struct {
 	new          bool
 }
 
+// ensure Unifi implements UnifiClient fully, will fail to compile otherwise
+var _ UnifiClient = &Unifi{}
+
 type fingerprints []string
 
 // Contains returns true if the fingerprint is in the list.

--- a/types.go
+++ b/types.go
@@ -210,6 +210,9 @@ type UnifiClient interface {
 	// GetServerData sets the controller's version and UUID. Only call this if you
 	// previously called Login and suspect the controller version has changed.
 	GetServerData() error
+	// GetUsers returns a response full of clients that connected to the UDM within the provided amount of time
+	// using the insight historical connection data set.
+	GetUsers(sites []*Site, hours int) ([]*User, error)
 }
 
 // Unifi is what you get in return for providing a password! Unifi represents

--- a/types.go
+++ b/types.go
@@ -3,11 +3,64 @@ package unifi
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
 )
+
+func init() {
+	gofakeit.AddFuncLookup("port", gofakeit.Info{
+		Category:    "custom",
+		Description: "Random Unifi Port integer value",
+		Example:     "8443",
+		Output:      "int",
+		Generate: func(r *rand.Rand, m *gofakeit.MapParams, info *gofakeit.Info) (interface{}, error) {
+			return r.Int31n(65535), nil
+		},
+	})
+
+	gofakeit.AddFuncLookup("timestamp", gofakeit.Info{
+		Category:    "custom",
+		Description: "Random timestamp value",
+		Example:     "123456",
+		Output:      "int64",
+		Generate: func(r *rand.Rand, m *gofakeit.MapParams, info *gofakeit.Info) (interface{}, error) {
+			return gofakeit.DateRange(time.Now().Add(time.Hour-2), time.Now()).Unix(), nil
+		},
+	})
+
+	gofakeit.AddFuncLookup("timestamps", gofakeit.Info{
+		Category:    "custom",
+		Description: "Random timestamp value",
+		Example:     "123456",
+		Output:      "[]int64",
+		Params: []gofakeit.Param{
+			{
+				Field:       "length",
+				Display:     "number of items to generate",
+				Type:        "uint",
+				Optional:    false,
+				Default:     "2",
+				Description: "The number of ints to generate",
+			},
+		},
+		Generate: func(r *rand.Rand, m *gofakeit.MapParams, info *gofakeit.Info) (interface{}, error) {
+			l, err := info.GetUint(m, "length")
+			if err != nil {
+				return nil, err
+			}
+			result := make([]int64, 0)
+			for i := 0; i < int(l); i++ {
+				result = append(result, gofakeit.DateRange(time.Now().Add(time.Hour-2), time.Now()).Unix())
+			}
+			return result, nil
+		},
+	})
+}
 
 var ErrCannotUnmarshalFlexInt = fmt.Errorf("cannot unmarshal to FlexInt")
 
@@ -100,6 +153,63 @@ type Config struct {
 	DebugLog  Logger
 	Timeout   time.Duration // how long to wait for replies, default: forever.
 	VerifySSL bool
+}
+
+type UnifiClient interface {
+	// GetAlarms returns Alarms for a list of Sites.
+	GetAlarms(sites []*Site) ([]*Alarm, error)
+	// GetAlarmsSite retreives the Alarms for a single Site.
+	GetAlarmsSite(site *Site) ([]*Alarm, error)
+	// GetAnomalies returns Anomalies for a list of Sites.
+	GetAnomalies(sites []*Site, timeRange ...time.Time) ([]*Anomaly, error)
+	// GetAnomaliesSite retreives the Anomalies for a single Site.
+	GetAnomaliesSite(site *Site, timeRange ...time.Time) ([]*Anomaly, error)
+	// GetClients returns a response full of clients' data from the UniFi Controller.
+	GetClients(sites []*Site) ([]*Client, error)
+	// GetClientsDPI garners dpi data for clients.
+	GetClientsDPI(sites []*Site) ([]*DPITable, error)
+	// GetDevices returns a response full of devices' data from the UniFi Controller.
+	GetDevices(sites []*Site) (*Devices, error)
+	// GetUSWs returns all switches, an error, or nil if there are no switches.
+	GetUSWs(site *Site) ([]*USW, error)
+	// GetUAPs returns all access points, an error, or nil if there are no APs.
+	GetUAPs(site *Site) ([]*UAP, error)
+	// GetUDMs returns all dream machines, an error, or nil if there are no UDMs.
+	GetUDMs(site *Site) ([]*UDM, error)
+	// GetUXGs returns all 10Gb gateways, an error, or nil if there are no UXGs.
+	GetUXGs(site *Site) ([]*UXG, error)
+	// GetUSGs returns all 1Gb gateways, an error, or nil if there are no USGs.
+	GetUSGs(site *Site) ([]*USG, error)
+	// GetEvents returns a response full of UniFi Events for the last 1 hour from multiple sites.
+	GetEvents(sites []*Site, hours time.Duration) ([]*Event, error)
+	// GetSiteEvents retrieves the last 1 hour's worth of events from a single site.
+	GetSiteEvents(site *Site, hours time.Duration) ([]*Event, error)
+	// GetIDS returns Intrusion Detection Systems events for a list of Sites.
+	// timeRange may have a length of 0, 1 or 2. The first time is Start, the second is End.
+	// Events between start and end are returned. End defaults to time.Now().
+	GetIDS(sites []*Site, timeRange ...time.Time) ([]*IDS, error)
+	// GetIDSSite retrieves the Intrusion Detection System Data for a single Site.
+	// timeRange may have a length of 0, 1 or 2. The first time is Start, the second is End.
+	// Events between start and end are returned. End defaults to time.Now().
+	GetIDSSite(site *Site, timeRange ...time.Time) ([]*IDS, error)
+	// GetNetworks returns a response full of network data from the UniFi Controller.
+	GetNetworks(sites []*Site) ([]Network, error)
+	// GetSites returns a list of configured sites on the UniFi controller.
+	GetSites() ([]*Site, error)
+	// GetSiteDPI garners dpi data for sites.
+	GetSiteDPI(sites []*Site) ([]*DPITable, error)
+	// GetRogueAPs returns RogueAPs for a list of Sites.
+	// Use GetRogueAPsSite if you want more control.
+	GetRogueAPs(sites []*Site) ([]*RogueAP, error)
+	// GetRogueAPsSite returns RogueAPs for a single Site.
+	GetRogueAPsSite(site *Site) ([]*RogueAP, error)
+	// Login is a helper method. It can be called to grab a new authentication cookie.
+	Login() error
+	// Logout closes the current session.
+	Logout() error
+	// GetServerData sets the controller's version and UUID. Only call this if you
+	// previously called Login and suspect the controller version has changed.
+	GetServerData() error
 }
 
 // Unifi is what you get in return for providing a password! Unifi represents
@@ -197,6 +307,19 @@ func (f *FlexInt) AddFloat64(v float64) {
 	f.Txt = strconv.FormatFloat(f.Val, 'f', -1, 64)
 }
 
+// Fake implements gofakeit Fake interface
+func (f *FlexInt) Fake(faker *gofakeit.Faker) interface{} {
+	randValue := faker.Rand.Float64()
+	opts := []interface{}{
+		randValue,
+		int64(randValue),
+		strconv.FormatInt(int64(randValue), 10),
+		strconv.FormatFloat(randValue, 'f', 8, 64),
+	}
+
+	return opts[faker.Rand.Intn(2)]
+}
+
 // FlexBool provides a container and unmarshalling for fields that may be
 // boolean or strings in the Unifi API.
 type FlexBool struct {
@@ -220,24 +343,35 @@ func (f *FlexBool) String() string {
 	return f.Txt
 }
 
+// Fake implements gofakeit Fake interface
+func (f *FlexBool) Fake(faker *gofakeit.Faker) interface{} {
+	opts := []interface{}{
+		"true",
+		true,
+		"false",
+		false,
+	}
+	return opts[faker.Rand.Intn(4)]
+}
+
 // DownlinkTable is part of a UXG and UDM output.
 type DownlinkTable struct {
-	PortIdx    FlexInt  `json:"port_idx"`
+	PortIdx    FlexInt  `json:"port_idx" fake:"{port}"`
 	Speed      FlexInt  `json:"speed"`
 	FullDuplex FlexBool `json:"full_duplex"`
-	Mac        string   `json:"mac"`
+	Mac        string   `json:"mac" fake:"{macaddress}"`
 }
 
 // ConfigNetwork comes from gateways.
 type ConfigNetwork struct {
-	Type string `json:"type"`
-	IP   string `json:"ip"`
+	Type string `json:"type" fake:"{randomstring:[wan,lan,vlan]}"`
+	IP   string `json:"ip" fake:"{ipv4address}"`
 }
 
 type EthernetTable struct {
-	Mac     string  `json:"mac"`
-	NumPort FlexInt `json:"num_port"`
-	Name    string  `json:"name"`
+	Mac     string  `json:"mac" fake:"{macaddress}"`
+	NumPort FlexInt `json:"num_port" fake:"{port}"`
+	Name    string  `json:"name" fake:"{animal}"`
 }
 
 // Port is a physical connection on a USW or Gateway.
@@ -246,23 +380,23 @@ type Port struct {
 	AggregatedBy       FlexBool   `json:"aggregated_by"`
 	Autoneg            FlexBool   `json:"autoneg,omitempty"`
 	BytesR             FlexInt    `json:"bytes-r"`
-	DNS                []string   `json:"dns,omitempty"`
+	DNS                []string   `json:"dns,omitempty" fakesize:"5"`
 	Dot1XMode          string     `json:"dot1x_mode"`
 	Dot1XStatus        string     `json:"dot1x_status"`
 	Enable             FlexBool   `json:"enable"`
 	FlowctrlRx         FlexBool   `json:"flowctrl_rx"`
 	FlowctrlTx         FlexBool   `json:"flowctrl_tx"`
 	FullDuplex         FlexBool   `json:"full_duplex"`
-	IP                 string     `json:"ip,omitempty"`
-	Ifname             string     `json:"ifname,omitempty"`
+	IP                 string     `json:"ip,omitempty" fake:"{ipv4address}"`
+	Ifname             string     `json:"ifname,omitempty" fake:"{randomstring:[wlan0,wlan1,lan0,lan1,vlan1,vlan0,vlan2]}"`
 	IsUplink           FlexBool   `json:"is_uplink"`
-	Mac                string     `json:"mac,omitempty"`
-	MacTable           []MacTable `json:"mac_table,omitempty"`
+	Mac                string     `json:"mac,omitempty" fake:"{macaddress}"`
+	MacTable           []MacTable `json:"mac_table,omitempty" fakesize:"5"`
 	Jumbo              FlexBool   `json:"jumbo,omitempty"`
 	Masked             FlexBool   `json:"masked"`
 	Media              string     `json:"media"`
-	Name               string     `json:"name"`
-	NetworkName        string     `json:"network_name,omitempty"`
+	Name               string     `json:"name" fake:"{animal}"`
+	NetworkName        string     `json:"network_name,omitempty" fake:"{animal}"`
 	Netmask            string     `json:"netmask,omitempty"`
 	NumPort            FlexInt    `json:"num_port,omitempty"`
 	OpMode             string     `json:"op_mode"`

--- a/uap.go
+++ b/uap.go
@@ -15,11 +15,11 @@ type UAP struct {
 	Adopted               FlexBool `json:"adopted"`
 	AntennaTable          []struct {
 		Default   FlexBool `json:"default"`
-		ID        FlexInt  `json:"id"`
-		Name      string   `json:"name"`
+		ID        FlexInt  `json:"id" fake:"{uuid}"`
+		Name      string   `json:"name" fake:"{animal}"`
 		Wifi0Gain FlexInt  `json:"wifi0_gain"`
 		Wifi1Gain FlexInt  `json:"wifi1_gain"`
-	} `json:"antenna_table"`
+	} `json:"antenna_table" fakesize:"5"`
 	Architecture         string           `json:"architecture"`
 	BandsteeringMode     string           `json:"bandsteering_mode,omitempty"`
 	BoardRev             int              `json:"board_rev"`
@@ -28,18 +28,18 @@ type UAP struct {
 	BytesR               FlexInt          `json:"bytes-r"`
 	Cfgversion           string           `json:"cfgversion"`
 	ConfigNetwork        *ConfigNetwork   `json:"config_network"`
-	ConnectRequestIP     string           `json:"connect_request_ip"`
+	ConnectRequestIP     string           `json:"connect_request_ip" fake:"{ipv4address}"`
 	ConnectRequestPort   string           `json:"connect_request_port"`
-	ConnectedAt          FlexInt          `json:"connected_at"`
+	ConnectedAt          FlexInt          `json:"connected_at" fake:"{timestamp}"`
 	CountryCode          FlexInt          `json:"country_code"`
-	CountrycodeTable     []int            `json:"countrycode_table"`
-	DeviceID             string           `json:"device_id"`
+	CountrycodeTable     []int            `json:"countrycode_table" fakesize:"5"`
+	DeviceID             string           `json:"device_id" fake:"{uuid}"`
 	Dot1XPortctrlEnabled FlexBool         `json:"dot1x_portctrl_enabled"`
-	DownlinkTable        []*DownlinkTable `json:"downlink_table,omitempty"`
-	EthernetTable        []*EthernetTable `json:"ethernet_table"`
+	DownlinkTable        []*DownlinkTable `json:"downlink_table,omitempty" fakesize:"5"`
+	EthernetTable        []*EthernetTable `json:"ethernet_table" fakesize:"5"`
 	FixedAPAvailable     FlexBool         `json:"fixed_ap_available"`
 	FwCaps               int              `json:"fw_caps"`
-	GatewayMac           string           `json:"gateway_mac"`
+	GatewayMac           string           `json:"gateway_mac" fake:"{macaddress}"`
 	GuestNumSta          FlexInt          `json:"guest-num_sta"`
 	GuestToken           string           `json:"guest_token"`
 	GuestWlanNumSta      FlexInt          `json:"guest-wlan-num_sta"`
@@ -48,18 +48,18 @@ type UAP struct {
 	HasSpeaker           FlexBool         `json:"has_speaker"`
 	HasTemperature       FlexBool         `json:"has_temperature"`
 	HwCaps               int              `json:"hw_caps"`
-	ID                   string           `json:"_id"`
-	IP                   string           `json:"ip"`
-	InformIP             string           `json:"inform_ip"`
-	InformURL            string           `json:"inform_url"`
+	ID                   string           `json:"_id" fake:"{uuid}"`
+	IP                   string           `json:"ip" fake:"{ipv4address}"`
+	InformIP             string           `json:"inform_ip" fake:"{ipv4address}"`
+	InformURL            string           `json:"inform_url" fake:"{url}"`
 	Internet             FlexBool         `json:"internet"`
 	Isolated             FlexBool         `json:"isolated"`
 	KernelVersion        string           `json:"kernel_version"`
 	KnownCfgversion      string           `json:"known_cfgversion"`
 	LastSeen             FlexInt          `json:"last_seen"`
 	LastUplink           struct {
-		UplinkMac        string `json:"uplink_mac"`
-		UplinkRemotePort int    `json:"uplink_remote_port"`
+		UplinkMac        string `json:"uplink_mac" fake:"{macaddress}"`
+		UplinkRemotePort int    `json:"uplink_remote_port" fake:"{port}"`
 	} `json:"last_uplink"`
 	LcmBrightnessOverride         FlexBool        `json:"lcm_brightness_override"`
 	LcmTimeoutOverride            FlexBool        `json:"lcm_idle_timeout_override"`
@@ -81,7 +81,7 @@ type UAP struct {
 	LteHardLimit                  FlexInt         `json:"lte_hard_limit"`
 	LteICCID                      string          `json:"lte_iccid"`
 	LteIMEI                       string          `json:"lte_imei"`
-	LteIP                         string          `json:"lte_ip"`
+	LteIP                         string          `json:"lte_ip" fake:"{ipv4address}"`
 	LteMode                       string          `json:"lte_mode"`
 	LteNetworkOperator            string          `json:"lte_networkoperator"`
 	LtePdpType                    string          `json:"lte_pdptype"`
@@ -101,7 +101,7 @@ type UAP struct {
 	LteSubscriptionCheckRequired  FlexBool        `json:"lte_subscription_check_required"`
 	LteSubscriptionStatus         FlexBool        `json:"lte_subscription_status"`
 	LteTxChannel                  FlexInt         `json:"lte_tx_chan"`
-	Mac                           string          `json:"mac"`
+	Mac                           string          `json:"mac" fake:"{macaddress}"`
 	ManufacturerID                FlexInt         `json:"manufacturer_id"`
 	MeshStaVapEnabled             FlexBool        `json:"mesh_sta_vap_enabled"`
 	Meshv3PeerMac                 string          `json:"meshv3_peer_mac"`
@@ -112,7 +112,7 @@ type UAP struct {
 	Name                          string          `json:"name"`
 	NumSta                        FlexInt         `json:"num_sta"`
 	OutdoorModeOverride           string          `json:"outdoor_mode_override"`
-	PortTable                     []Port          `json:"port_table"`
+	PortTable                     []Port          `json:"port_table" fakesize:"5"`
 	ProvisionedAt                 FlexInt         `json:"provisioned_at"`
 	RadioTable                    RadioTable      `json:"radio_table"`
 	RadioTableStats               RadioTableStats `json:"radio_table_stats"`
@@ -125,13 +125,13 @@ type UAP struct {
 	ScanRadioTable                []interface{}   `json:"scan_radio_table"`
 	Scanning                      FlexBool        `json:"scanning"`
 	Serial                        string          `json:"serial"`
-	SiteID                        string          `json:"site_id"`
+	SiteID                        string          `json:"site_id" fake:"{uuid}"`
 	SiteName                      string          `json:"-"`
 	SourceName                    string          `json:"-"`
 	SpectrumScanning              FlexBool        `json:"spectrum_scanning"`
-	StartConnectedMillis          FlexInt         `json:"start_connected_millis"`
-	StartDisconnectedMillis       FlexInt         `json:"start_disconnected_millis"`
-	StartupTimestamp              FlexInt         `json:"startup_timestamp"`
+	StartConnectedMillis          FlexInt         `json:"start_connected_millis" fake:"{timestamp}"`
+	StartDisconnectedMillis       FlexInt         `json:"start_disconnected_millis" fake:"{timestamp}"`
+	StartupTimestamp              FlexInt         `json:"startup_timestamp" fake:"{timestamp}"`
 	Stat                          UAPStat         `json:"stat"`
 	State                         FlexInt         `json:"state"`
 	SupportsFingerprintML         FlexBool        `json:"supports_fingerprint_ml"`
@@ -152,12 +152,12 @@ type UAP struct {
 	UpgradeState                  FlexInt         `json:"upgrade_state"`
 	Uplink                        struct {
 		FullDuplex       FlexBool `json:"full_duplex"`
-		IP               string   `json:"ip"`
-		Mac              string   `json:"mac"`
+		IP               string   `json:"ip" fake:"{ipv4address}"`
+		Mac              string   `json:"mac" fake:"{macaddress}"`
 		MaxVlan          int      `json:"max_vlan"`
 		Name             string   `json:"name"`
 		Netmask          string   `json:"netmask"`
-		NumPort          int      `json:"num_port"`
+		NumPort          int      `json:"num_port" fake:"{port}"`
 		RxBytes          FlexInt  `json:"rx_bytes"`
 		RxDropped        FlexInt  `json:"rx_dropped"`
 		RxErrors         FlexInt  `json:"rx_errors"`
@@ -173,8 +173,8 @@ type UAP struct {
 		Type             string   `json:"type"`
 		TxBytesR         FlexInt  `json:"tx_bytes-r"`
 		RxBytesR         FlexInt  `json:"rx_bytes-r"`
-		UplinkMac        string   `json:"uplink_mac"`
-		UplinkRemotePort int      `json:"uplink_remote_port"`
+		UplinkMac        string   `json:"uplink_mac" fake:"{macaddress}"`
+		UplinkRemotePort int      `json:"uplink_remote_port" fake:"{port}"`
 	} `json:"uplink"`
 	UplinkTable    []interface{} `json:"uplink_table"`
 	Uptime         FlexInt       `json:"uptime"`
@@ -198,11 +198,11 @@ type UAPStat struct {
 
 // Ap is a subtype of UAPStat to make unmarshalling of different controller versions possible.
 type Ap struct {
-	SiteID                   string    `json:"site_id"`
+	SiteID                   string    `json:"site_id" fake:"{uuid}"`
 	O                        string    `json:"o"`
 	Oid                      string    `json:"oid"`
 	Ap                       string    `json:"ap"`
-	Time                     FlexInt   `json:"time"`
+	Time                     FlexInt   `json:"time" fake:"{timestamp}"`
 	Datetime                 time.Time `json:"datetime"`
 	Bytes                    FlexInt   `json:"bytes"`
 	Duration                 FlexInt   `json:"duration"`
@@ -440,7 +440,7 @@ type RadioTable []struct {
 	MinRssi            FlexInt  `json:"min_rssi,omitempty"`
 	MinRssiEnabled     FlexBool `json:"min_rssi_enabled"`
 	MinTxpower         FlexInt  `json:"min_txpower"`
-	Name               string   `json:"name"`
+	Name               string   `json:"name" fake:"{animal}"`
 	Nss                FlexInt  `json:"nss"`
 	Radio              string   `json:"radio"`
 	RadioCaps          FlexInt  `json:"radio_caps"`
@@ -448,12 +448,12 @@ type RadioTable []struct {
 	TxPower            FlexInt  `json:"tx_power"`
 	TxPowerMode        string   `json:"tx_power_mode"`
 	VwireEnabled       FlexBool `json:"vwire_enabled"`
-	WlangroupID        string   `json:"wlangroup_id"`
+	WlangroupID        string   `json:"wlangroup_id" fake:"{uuid}"`
 }
 
 // RadioTableStats is part of the data shared between UAP and UDM.
 type RadioTableStats []struct {
-	Name         string      `json:"name"`
+	Name         string      `json:"name" fake:"{animal}"`
 	Channel      FlexInt     `json:"channel"`
 	Radio        string      `json:"radio"`
 	AstTxto      interface{} `json:"ast_txto"`
@@ -541,10 +541,10 @@ type VapTable []struct {
 	} `json:"rx_tcp_stats"`
 	TxTCPStats struct {
 		Goodbytes FlexInt `json:"goodbytes"`
-		LatAvg    FlexInt `json:"lat_avg"`
-		LatMax    FlexInt `json:"lat_max"`
-		LatMin    FlexInt `json:"lat_min"`
-		Stalls    FlexInt `json:"stalls"`
+		LatAvg    FlexInt `json:"lat_avg" fake:"{latitude}"`
+		LatMax    FlexInt `json:"lat_max" fake:"{latitude}"`
+		LatMin    FlexInt `json:"lat_min" fake:"{longitude}"`
+		Stalls    FlexInt `json:"stalls" fake:"{longitude}"`
 	} `json:"tx_tcp_stats"`
 	WifiTxLatencyMov struct {
 		Avg        FlexInt `json:"avg"`
@@ -553,20 +553,20 @@ type VapTable []struct {
 		Total      FlexInt `json:"total"`
 		TotalCount FlexInt `json:"total_count"`
 	} `json:"wifi_tx_latency_mov"`
-	ApMac               string      `json:"ap_mac"`
+	ApMac               string      `json:"ap_mac" fake:"{macaddress}"`
 	AvgClientSignal     FlexInt     `json:"avg_client_signal"`
-	Bssid               string      `json:"bssid"`
+	Bssid               string      `json:"bssid" fake:"{macaddress}"`
 	Ccq                 int         `json:"ccq"`
 	Channel             FlexInt     `json:"channel"`
 	DNSAvgLatency       FlexInt     `json:"dns_avg_latency"`
-	Essid               string      `json:"essid"`
+	Essid               string      `json:"essid" fake:"{macaddress}"`
 	Extchannel          int         `json:"extchannel"`
-	ID                  string      `json:"id"`
+	ID                  string      `json:"id" fake:"{uuid}"`
 	IsGuest             FlexBool    `json:"is_guest"`
 	IsWep               FlexBool    `json:"is_wep"`
 	MacFilterRejections int         `json:"mac_filter_rejections"`
 	MapID               interface{} `json:"map_id"`
-	Name                string      `json:"name"`
+	Name                string      `json:"name" fake:"{animal}"`
 	NumSatisfactionSta  FlexInt     `json:"num_satisfaction_sta"`
 	NumSta              int         `json:"num_sta"`
 	Radio               string      `json:"radio"`
@@ -580,7 +580,7 @@ type VapTable []struct {
 	RxPackets           FlexInt     `json:"rx_packets"`
 	Satisfaction        FlexInt     `json:"satisfaction"`
 	SatisfactionNow     FlexInt     `json:"satisfaction_now"`
-	SiteID              string      `json:"site_id"`
+	SiteID              string      `json:"site_id" fake:"{uuid}"`
 	State               string      `json:"state"`
 	T                   string      `json:"t"`
 	TxBytes             FlexInt     `json:"tx_bytes"`
@@ -605,16 +605,16 @@ type VapTable []struct {
 type RogueAP struct {
 	SourceName string   `json:"-"`
 	SiteName   string   `json:"-"`
-	ID         string   `json:"_id"`
-	ApMac      string   `json:"ap_mac"`
-	Bssid      string   `json:"bssid"`
-	SiteID     string   `json:"site_id"`
+	ID         string   `json:"_id" fake:"{uuid}"`
+	ApMac      string   `json:"ap_mac" fake:"{macaddress}"`
+	Bssid      string   `json:"bssid" fake:"{macaddress}"`
+	SiteID     string   `json:"site_id" fake:"{uuid}"`
 	Age        FlexInt  `json:"age"`
 	Band       string   `json:"band"`
 	Bw         FlexInt  `json:"bw"`
 	CenterFreq FlexInt  `json:"center_freq"`
 	Channel    int      `json:"channel"`
-	Essid      string   `json:"essid"`
+	Essid      string   `json:"essid" fake:"{macaddress}"`
 	Freq       FlexInt  `json:"freq"`
 	IsAdhoc    FlexBool `json:"is_adhoc"`
 	IsRogue    FlexBool `json:"is_rogue"`

--- a/udm.go
+++ b/udm.go
@@ -37,7 +37,7 @@ type UDM struct {
 	EthernetTable                      []*EthernetTable     `json:"ethernet_table" fakesize:"5"`
 	FlowctrlEnabled                    FlexBool             `json:"flowctrl_enabled"`
 	FwCaps                             FlexInt              `json:"fw_caps"`
-	GeoInfo                            map[string]GeoInfo   `json:"geo_info" fakesize:"5""`
+	GeoInfo                            map[string]GeoInfo   `json:"geo_info" fakesize:"5"`
 	GuestKicks                         FlexInt              `json:"guest_kicks"`
 	GuestLanNumSta                     FlexInt              `json:"guest-lan-num_sta"` // USW
 	GuestNumSta                        FlexInt              `json:"guest-num_sta"`     // USG

--- a/udm.go
+++ b/udm.go
@@ -5,12 +5,12 @@ package unifi
 type UDM struct {
 	site                               *Site
 	AFTEnabled                         FlexBool             `json:"atf_enabled"`
-	AdoptIP                            string               `json:"adopt_ip"`
+	AdoptIP                            string               `json:"adopt_ip" fake:"{ipv4address}"`
 	AdoptManual                        FlexBool             `json:"adopt_manual"`
 	AdoptState                         FlexInt              `json:"adopt_state"`
 	AdoptStatus                        FlexInt              `json:"adopt_status"`
 	AdoptTries                         FlexInt              `json:"adopt_tries"`
-	AdoptURL                           string               `json:"adopt_url"`
+	AdoptURL                           string               `json:"adopt_url" fake:"{url}"`
 	AdoptableWhenUpgraded              FlexBool             `json:"adoptable_when_upgraded"`
 	Adopted                            FlexBool             `json:"adopted"`
 	AdoptionCompleted                  FlexBool             `json:"adoption_completed"`
@@ -22,22 +22,22 @@ type UDM struct {
 	BytesR                             FlexInt              `json:"bytes-r"`
 	Cfgversion                         string               `json:"cfgversion"`
 	ConfigNetwork                      *ConfigNetwork       `json:"config_network"`
-	ConnectRequestIP                   string               `json:"connect_request_ip"`
+	ConnectRequestIP                   string               `json:"connect_request_ip" fake:"{ipv4address}"`
 	ConnectRequestPort                 string               `json:"connect_request_port"`
-	ConnectedAt                        FlexInt              `json:"connected_at"`
+	ConnectedAt                        FlexInt              `json:"connected_at" fake:"{timestamp}"`
 	ConnectionNetworkName              string               `json:"connection_network_name"`
 	Default                            FlexBool             `json:"default"`
 	DeviceDomain                       string               `json:"device_domain"`
-	DeviceID                           string               `json:"device_id"`
+	DeviceID                           string               `json:"device_id" fake:"{uuid}"`
 	DiscoveredVia                      string               `json:"discovered_via"`
 	DisplayableVersion                 string               `json:"displayable_version"`
 	Dot1XPortctrlEnabled               FlexBool             `json:"dot1x_portctrl_enabled"`
-	DownlinkTable                      []*DownlinkTable     `json:"downlink_table"`
-	EthernetOverrides                  []*EthernetOverrides `json:"ethernet_overrides"`
-	EthernetTable                      []*EthernetTable     `json:"ethernet_table"`
+	DownlinkTable                      []*DownlinkTable     `json:"downlink_table" fakesize:"5"`
+	EthernetOverrides                  []*EthernetOverrides `json:"ethernet_overrides" fakesize:"5"`
+	EthernetTable                      []*EthernetTable     `json:"ethernet_table" fakesize:"5"`
 	FlowctrlEnabled                    FlexBool             `json:"flowctrl_enabled"`
 	FwCaps                             FlexInt              `json:"fw_caps"`
-	GeoInfo                            map[string]GeoInfo   `json:"geo_info"`
+	GeoInfo                            map[string]GeoInfo   `json:"geo_info" fakesize:"5""`
 	GuestKicks                         FlexInt              `json:"guest_kicks"`
 	GuestLanNumSta                     FlexInt              `json:"guest-lan-num_sta"` // USW
 	GuestNumSta                        FlexInt              `json:"guest-num_sta"`     // USG
@@ -48,20 +48,20 @@ type UDM struct {
 	HasSpeaker                         FlexBool             `json:"has_speaker"`
 	HasTemperature                     FlexBool             `json:"has_temperature"`
 	HwCaps                             FlexInt              `json:"hw_caps"`
-	ID                                 string               `json:"_id"`
-	IP                                 string               `json:"ip"`
-	InformIP                           string               `json:"inform_ip"`
-	InformURL                          string               `json:"inform_url"`
+	ID                                 string               `json:"_id" fake:"{uuid}"`
+	IP                                 string               `json:"ip" fake:"{ipv4address}"`
+	InformIP                           string               `json:"inform_ip" fake:"{ipv4address}"`
+	InformURL                          string               `json:"inform_url" fake:"{url}"`
 	Internet                           FlexBool             `json:"internet"`
 	IsAccessPoint                      FlexBool             `json:"is_access_point"`
 	JumboframeEnabled                  FlexBool             `json:"jumboframe_enabled"`
 	KernelVersion                      string               `json:"kernel_version"`
 	KnownCfgversion                    string               `json:"known_cfgversion"`
-	LanIP                              string               `json:"lan_ip"`
+	LanIP                              string               `json:"lan_ip" fake:"{ipv4address}"`
 	LanNumSta                          FlexInt              `json:"lan-num_sta"` // USW
-	LastLteFailoverTransitionTimestamp FlexInt              `json:"last_lte_failover_transition_timestamp"`
-	LastSeen                           FlexInt              `json:"last_seen"`
-	LastWlanIP                         string               `json:"last_wan_ip"`
+	LastLteFailoverTransitionTimestamp FlexInt              `json:"last_lte_failover_transition_timestamp" fake:"{timestamp}"`
+	LastSeen                           FlexInt              `json:"last_seen" fake:"{timestamp}"`
+	LastWlanIP                         string               `json:"last_wan_ip" fake:"{ipv4address}"`
 	LcmBrightness                      FlexInt              `json:"lcm_brightness"`
 	LcmNightModeBegins                 string               `json:"lcm_night_mode_begins"`
 	LcmNightModeEnabled                FlexBool             `json:"lcm_night_mode_enabled"`
@@ -70,14 +70,14 @@ type UDM struct {
 	LcmTrackerSeed                     string               `json:"lcm_tracker_seed"`
 	LicenseState                       string               `json:"license_state"`
 	Locating                           FlexBool             `json:"locating"`
-	Mac                                string               `json:"mac"`
+	Mac                                string               `json:"mac" fake:"{macaddress}"`
 	ManufacturerID                     FlexInt              `json:"manufacturer_id"`
 	MinInformIntervalSeconds           FlexInt              `json:"min_inform_interval_seconds"`
 	Model                              string               `json:"model"`
 	ModelInEOL                         FlexBool             `json:"model_in_eol"`
 	ModelInLTS                         FlexBool             `json:"model_in_lts"`
 	ModelIncompatible                  FlexBool             `json:"model_incompatible"`
-	Name                               string               `json:"name"`
+	Name                               string               `json:"name" fake:"{animal}"`
 	NetworkTable                       NetworkTable         `json:"network_table"`
 	NextInterval                       FlexInt              `json:"next_interval"`
 	NumDesktop                         FlexInt              `json:"num_desktop"`  // USG
@@ -86,12 +86,12 @@ type UDM struct {
 	NumSta                             FlexInt              `json:"num_sta"`      // USG
 	Overheating                        FlexBool             `json:"overheating"`
 	PortOverrides                      []struct {
-		PortIdx    FlexInt `json:"port_idx"`
+		PortIdx    FlexInt `json:"port_idx" fake:"{port}"`
 		PortconfID string  `json:"portconf_id"`
-	} `json:"port_overrides"`
-	PortTable              []Port           `json:"port_table"`
+	} `json:"port_overrides" fakesize:"5"`
+	PortTable              []Port           `json:"port_table" fakesize:"5"`
 	PowerSourceCtrlEnabled FlexBool         `json:"power_source_ctrl_enabled"`
-	ProvisionedAt          FlexInt          `json:"provisioned_at"`
+	ProvisionedAt          FlexInt          `json:"provisioned_at" fake:"{timestamp}"`
 	RadioTable             *RadioTable      `json:"radio_table,omitempty"`
 	RadioTableStats        *RadioTableStats `json:"radio_table_stats,omitempty"`
 	RequiredVersion        string           `json:"required_version"`
@@ -114,17 +114,17 @@ type UDM struct {
 	Serial                    string          `json:"serial"`
 	SetupProvisionCompleted   FlexBool        `json:"setup_provision_completed"`
 	SetupProvisionTracking    FlexBool        `json:"setup_provision_tracking"`
-	SiteID                    string          `json:"site_id"`
+	SiteID                    string          `json:"site_id" fake:"{uuid}"`
 	SiteName                  string          `json:"-"`
 	SourceName                string          `json:"-"`
 	SpeedtestStatus           SpeedtestStatus `json:"speedtest-status"`
 	SpeedtestStatusSaved      FlexBool        `json:"speedtest-status-saved"`
-	StartupConnectedMillis    FlexInt         `json:"start_connected_millis"`
-	StartupDisconnectedMillis FlexInt         `json:"start_disconnected_millis"`
-	StartupTimestamp          FlexInt         `json:"startup_timestamp"`
+	StartupConnectedMillis    FlexInt         `json:"start_connected_millis" fake:"{timestamp}"`
+	StartupDisconnectedMillis FlexInt         `json:"start_disconnected_millis" fake:"{timestamp}"`
+	StartupTimestamp          FlexInt         `json:"startup_timestamp" fake:"{timestamp}"`
 	Stat                      UDMStat         `json:"stat"`
 	State                     FlexInt         `json:"state"`
-	Storage                   []*Storage      `json:"storage"`
+	Storage                   []*Storage      `json:"storage" fakesize:"5"`
 	StpPriority               FlexInt         `json:"stp_priority"`
 	StpVersion                string          `json:"stp_version"`
 	SwitchCaps                struct {
@@ -135,7 +135,7 @@ type UDM struct {
 	SyslogKey       string        `json:"syslog_key"`
 	SystemStats     SystemStats   `json:"system-stats"`
 	TeleportVersion FlexInt       `json:"teleport_version"`
-	Temperatures    []Temperature `json:"temperatures,omitempty"`
+	Temperatures    []Temperature `json:"temperatures,omitempty" fakesize:"5"`
 	TwoPhaseAdopt   FlexBool      `json:"two_phase_adopt"`
 	TxBytes         FlexInt       `json:"tx_bytes"`
 	TxBytesD        FlexInt       `json:"tx_bytes-d"`
@@ -143,21 +143,21 @@ type UDM struct {
 	UdapiCaps       FlexInt       `json:"udapi_caps"`
 	UnifiCare       struct {
 		ActivationDismissed FlexBool `json:"activation_dismissed"`
-		ActivationEnd       FlexInt  `json:"activation_end"`
-		ActivationUrl       string   `json:"activation_url"`
-		CoverageEnd         FlexInt  `json:"coverage_end"`
-		CoverageStart       FlexInt  `json:"coverage_start"`
-		Registration        FlexInt  `json:"registration"`
-		RmaUrl              string   `json:"rma_url"`
+		ActivationEnd       FlexInt  `json:"activation_end" fake:"{timestamp}"`
+		ActivationUrl       string   `json:"activation_url" fake:"{url}"`
+		CoverageEnd         FlexInt  `json:"coverage_end" fake:"{timestamp}"`
+		CoverageStart       FlexInt  `json:"coverage_start" fake:"{timestamp}"`
+		Registration        FlexInt  `json:"registration" fake:"{timestamp}"`
+		RmaUrl              string   `json:"rma_url" fake:"{url}"`
 		State               string   `json:"state"`
-		TrackingUrl         string   `json:"tracking_url"`
+		TrackingUrl         string   `json:"tracking_url" fake:"{url}"`
 	} `json:"unifi_care"`
 	Unsupported       FlexBool      `json:"unsupported"`
 	UnsupportedReason FlexInt       `json:"unsupported_reason"`
 	UpgradeState      FlexInt       `json:"upgrade_state"`
 	Upgradeable       FlexBool      `json:"upgradable"`
 	Uplink            Uplink        `json:"uplink"`
-	Uptime            FlexInt       `json:"uptime"`
+	Uptime            FlexInt       `json:"uptime" fake:"{timestamp}"`
 	UserLanNumSta     FlexInt       `json:"user-lan-num_sta"`  // USW
 	UserNumSta        FlexInt       `json:"user-num_sta"`      // USG
 	UserWlanNumSta    FlexInt       `json:"user-wlan-num_sta"` // UAP
@@ -182,7 +182,7 @@ type EthernetOverrides struct {
 // NetworkTable is the list of networks on a gateway.
 // Not all gateways have all features.
 type NetworkTable []struct {
-	ID                     string    `json:"_id"`
+	ID                     string    `json:"_id" fake:"{uuid}"`
 	ActiveDhcpLeaseCount   FlexInt   `json:"active_dhcp_lease_count"`
 	AttrHiddenID           string    `json:"attr_hidden_id"`
 	AttrNoDelete           FlexBool  `json:"attr_no_delete"`
@@ -204,7 +204,7 @@ type NetworkTable []struct {
 	DPIStatsTable          *DPITable `json:"dpistats_table"`
 	Enabled                FlexBool  `json:"enabled"`
 	GatewayInterfaceName   string    `json:"gateway_interface_name"`
-	IP                     string    `json:"ip"`
+	IP                     string    `json:"ip" fake:"{ipv4address}"`
 	IPSubnet               string    `json:"ip_subnet"`
 	Ipv6InterfaceType      string    `json:"ipv6_interface_type"`
 	Ipv6PdStart            string    `json:"ipv6_pd_start"`
@@ -213,14 +213,14 @@ type NetworkTable []struct {
 	IsGuest                FlexBool  `json:"is_guest"`
 	IsNat                  FlexBool  `json:"is_nat"`
 	LteLanEnabled          FlexBool  `json:"lte_lan_enabled"`
-	Mac                    string    `json:"mac"`
-	Name                   string    `json:"name"`
+	Mac                    string    `json:"mac" fake:"{macaddress}"`
+	Name                   string    `json:"name" fake:"{animal}"`
 	Networkgroup           string    `json:"networkgroup"`
 	NumSta                 FlexInt   `json:"num_sta"`
 	Purpose                string    `json:"purpose"`
 	RxBytes                FlexInt   `json:"rx_bytes"`
 	RxPackets              FlexInt   `json:"rx_packets"`
-	SiteID                 string    `json:"site_id"`
+	SiteID                 string    `json:"site_id" fake:"{uuid}"`
 	TxBytes                FlexInt   `json:"tx_bytes"`
 	TxPackets              FlexInt   `json:"tx_packets"`
 	Up                     FlexBool  `json:"up"`
@@ -230,14 +230,14 @@ type NetworkTable []struct {
 // Storage is hard drive into for a device with storage.
 type Storage struct {
 	MountPoint string  `json:"mount_point"`
-	Name       string  `json:"name"`
+	Name       string  `json:"name" fake:"{animal}"`
 	Size       FlexInt `json:"size"`
 	Type       string  `json:"type"`
 	Used       FlexInt `json:"used"`
 }
 
 type Temperature struct {
-	Name  string  `json:"name"`
+	Name  string  `json:"name" fake:"{animal}"`
 	Type  string  `json:"type"`
 	Value float64 `json:"value"`
 }

--- a/users.go
+++ b/users.go
@@ -45,13 +45,13 @@ func (u *Unifi) GetUsers(sites []*Site, hours int) ([]*User, error) {
 type User struct {
 	SourceName          string   `json:"-"`
 	SiteName            string   `json:"-"`
-	ID                  string   `json:"_id"`
-	Mac                 string   `json:"mac"`
-	SiteID              string   `json:"site_id"`
+	ID                  string   `json:"_id" fake:"{uuid}"`
+	Mac                 string   `json:"mac" fake:"{macaddress}"`
+	SiteID              string   `json:"site_id" fake:"{uuid}"`
 	Oui                 string   `json:"oui,omitempty"`
 	IsGuest             bool     `json:"is_guest"`
-	FirstSeen           FlexInt  `json:"first_seen,omitempty"`
-	LastSeen            FlexInt  `json:"last_seen,omitempty"`
+	FirstSeen           FlexInt  `json:"first_seen,omitempty" fake:"{timestamp}"`
+	LastSeen            FlexInt  `json:"last_seen,omitempty" fake:"{timestamp}"`
 	IsWired             bool     `json:"is_wired,omitempty"`
 	Hostname            string   `json:"hostname,omitempty"`
 	Duration            FlexInt  `json:"duration,omitempty"`
@@ -62,12 +62,12 @@ type User struct {
 	WifiTxAttempts      FlexInt  `json:"wifi_tx_attempts,omitempty"`
 	TxRetries           FlexInt  `json:"tx_retries,omitempty"`
 	UsergroupID         string   `json:"usergroup_id,omitempty"`
-	Name                string   `json:"name,omitempty"`
-	Note                string   `json:"note,omitempty"`
+	Name                string   `json:"name,omitempty" fake:"{animal}"`
+	Note                string   `json:"note,omitempty" fake:"{sentence:20}"`
 	Noted               FlexBool `json:"noted,omitempty"`
 	Blocked             FlexBool `json:"blocked,omitempty"`
 	DevIDOverride       FlexInt  `json:"dev_id_override,omitempty"`
 	FingerprintOverride FlexBool `json:"fingerprint_override,omitempty"`
 	UseFixedIp          FlexBool `json:"use_fixedip,omitempty"`
-	FixedIp             string   `json:"fixed_ip,omitempty"`
+	FixedIp             string   `json:"fixed_ip,omitempty" fake:"{ipv4address}"`
 }

--- a/usg.go
+++ b/usg.go
@@ -9,53 +9,53 @@ import (
 type USG struct {
 	site                  *Site
 	SourceName            string               `json:"-"`
-	ID                    string               `json:"_id"`
+	ID                    string               `json:"_id" fake:"{uuid}"`
 	Adopted               FlexBool             `json:"adopted"`
 	Cfgversion            string               `json:"cfgversion"`
 	ConfigNetwork         *ConfigNetwork       `json:"config_network"`
-	EthernetTable         []*EthernetTable     `json:"ethernet_table"`
+	EthernetTable         []*EthernetTable     `json:"ethernet_table" fakesize:"5"`
 	FwCaps                FlexInt              `json:"fw_caps"`
-	InformIP              string               `json:"inform_ip"`
-	InformURL             string               `json:"inform_url"`
-	IP                    string               `json:"ip"`
+	InformIP              string               `json:"inform_ip" fake:"{ipv4address}"`
+	InformURL             string               `json:"inform_url" fake:"{url}"`
+	IP                    string               `json:"ip" fake:"{ipv4address}"`
 	LedOverride           string               `json:"led_override"`
 	LicenseState          string               `json:"license_state"`
-	Mac                   string               `json:"mac"`
+	Mac                   string               `json:"mac" fake:"{macaddress}"`
 	Model                 string               `json:"model"`
-	Name                  string               `json:"name"`
+	Name                  string               `json:"name" fake:"{animal}"`
 	OutdoorModeOverride   string               `json:"outdoor_mode_override"`
 	Serial                string               `json:"serial"`
-	SiteID                string               `json:"site_id"`
+	SiteID                string               `json:"site_id" fake:"{uuid}"`
 	SiteName              string               `json:"-"`
 	Type                  string               `json:"type"`
 	UsgCaps               FlexInt              `json:"usg_caps"`
 	Version               string               `json:"version"`
 	RequiredVersion       string               `json:"required_version"`
-	EthernetOverrides     []*EthernetOverrides `json:"ethernet_overrides"`
+	EthernetOverrides     []*EthernetOverrides `json:"ethernet_overrides" fakesize:"5"`
 	HwCaps                FlexInt              `json:"hw_caps"`
 	BoardRev              FlexInt              `json:"board_rev"`
 	Unsupported           FlexBool             `json:"unsupported"`
 	UnsupportedReason     FlexInt              `json:"unsupported_reason"`
-	DeviceID              string               `json:"device_id"`
+	DeviceID              string               `json:"device_id" fake:"{uuid}"`
 	State                 FlexInt              `json:"state"`
-	LastSeen              FlexInt              `json:"last_seen"`
+	LastSeen              FlexInt              `json:"last_seen" fake:"{timestamp}"`
 	Upgradable            FlexBool             `json:"upgradable"`
 	AdoptableWhenUpgraded FlexBool             `json:"adoptable_when_upgraded"`
 	Rollupgrade           FlexBool             `json:"rollupgrade"`
 	KnownCfgversion       string               `json:"known_cfgversion"`
-	Uptime                FlexInt              `json:"uptime"`
+	Uptime                FlexInt              `json:"uptime" fake:"{timestamp}"`
 	Locating              FlexBool             `json:"locating"`
-	ConnectRequestIP      string               `json:"connect_request_ip"`
+	ConnectRequestIP      string               `json:"connect_request_ip" fake:"{ipv4address}"`
 	ConnectRequestPort    string               `json:"connect_request_port"`
 	SysStats              SysStats             `json:"sys_stats"`
-	Temperatures          []Temperature        `json:"temperatures,omitempty"`
+	Temperatures          []Temperature        `json:"temperatures,omitempty" fakesize:"5"`
 	SystemStats           SystemStats          `json:"system-stats"`
 	GuestToken            string               `json:"guest_token"`
 	SpeedtestStatus       SpeedtestStatus      `json:"speedtest-status"`
 	SpeedtestStatusSaved  FlexBool             `json:"speedtest-status-saved"`
 	Wan1                  Wan                  `json:"wan1"`
 	Wan2                  Wan                  `json:"wan2"`
-	PortTable             []*Port              `json:"port_table"`
+	PortTable             []*Port              `json:"port_table" fakesize:"5"`
 	NetworkTable          NetworkTable         `json:"network_table"`
 	Uplink                Uplink               `json:"uplink"`
 	Stat                  USGStat              `json:"stat"`
@@ -76,12 +76,12 @@ type Uplink struct {
 	Drops            FlexInt  `json:"drops"`
 	Enable           FlexBool `json:"enable,omitempty"`
 	FullDuplex       FlexBool `json:"full_duplex"`
-	Gateways         []string `json:"gateways,omitempty"`
-	IP               string   `json:"ip"`
+	Gateways         []string `json:"gateways,omitempty" fakesize:"5"`
+	IP               string   `json:"ip" fake:"{ipv4address}"`
 	Latency          FlexInt  `json:"latency"`
 	Mac              string   `json:"mac,omitempty"`
 	MaxSpeed         FlexInt  `json:"max_speed"`
-	Name             string   `json:"name"`
+	Name             string   `json:"name" fake:"{animal}"`
 	Nameservers      []string `json:"nameservers"`
 	Netmask          string   `json:"netmask"`
 	NumPort          FlexInt  `json:"num_port"`
@@ -106,7 +106,7 @@ type Uplink struct {
 	TxRate           FlexInt  `json:"tx_rate"`
 	Type             string   `json:"type"`
 	Up               FlexBool `json:"up"`
-	Uptime           FlexInt  `json:"uptime"`
+	Uptime           FlexInt  `json:"uptime" fake:"{timestamp}"`
 	XputDown         FlexInt  `json:"xput_down,omitempty"`
 	XputUp           FlexInt  `json:"xput_up,omitempty"`
 }
@@ -115,19 +115,19 @@ type Uplink struct {
 type Wan struct {
 	Autoneg     FlexBool `json:"autoneg"`
 	BytesR      FlexInt  `json:"bytes-r"`
-	DNS         []string `json:"dns"` // may be deprecated
+	DNS         []string `json:"dns" fakesize:"5"` // may be deprecated
 	Enable      FlexBool `json:"enable"`
 	FlowctrlRx  FlexBool `json:"flowctrl_rx"`
 	FlowctrlTx  FlexBool `json:"flowctrl_tx"`
 	FullDuplex  FlexBool `json:"full_duplex"`
 	Gateway     string   `json:"gateway"` // may be deprecated
-	IP          string   `json:"ip"`
+	IP          string   `json:"ip" fake:"{ipv4address}"`
 	Ifname      string   `json:"ifname"`
 	IsUplink    FlexBool `json:"is_uplink"`
-	Mac         string   `json:"mac"`
+	Mac         string   `json:"mac" fake:"{macaddress}"`
 	MaxSpeed    FlexInt  `json:"max_speed"`
 	Media       string   `json:"media"`
-	Name        string   `json:"name"`
+	Name        string   `json:"name" fake:"{animal}"`
 	Netmask     string   `json:"netmask"` // may be deprecated
 	NumPort     int      `json:"num_port"`
 	PortIdx     int      `json:"port_idx"`
@@ -172,22 +172,22 @@ type SpeedtestStatus struct {
 
 type SpeedtestServer struct {
 	Cc          string  `json:"cc"`
-	City        string  `json:"city"`
-	Country     string  `json:"country"`
-	Lat         FlexInt `json:"lat"`
-	Lon         FlexInt `json:"lon"`
+	City        string  `json:"city" fake:"{city}"`
+	Country     string  `json:"country" fake:"{country}"`
+	Lat         FlexInt `json:"lat" fake:"{latitude}"`
+	Lon         FlexInt `json:"lon" fake:"{longitude}"`
 	Provider    string  `json:"provider"`
-	ProviderURL string  `json:"provider_url"`
+	ProviderURL string  `json:"provider_url" fake:"{url}"`
 }
 
 // SystemStats is system info for a UDM, USG, USW.
 type SystemStats struct {
 	CPU    FlexInt `json:"cpu"`
 	Mem    FlexInt `json:"mem"`
-	Uptime FlexInt `json:"uptime"`
+	Uptime FlexInt `json:"uptime" fake:"{timestamp}"`
 	// This exists on at least USG4, may others, maybe not.
 	// {"Board (CPU)":"51 C","Board (PHY)":"51 C","CPU":"72 C","PHY":"77 C"}
-	Temps map[string]string `json:"temps,omitempty"`
+	Temps map[string]string `json:"temps,omitempty" fakesize:"5"`
 }
 
 // SysStats is load info for a UDM, USG, USW.

--- a/usw.go
+++ b/usw.go
@@ -140,11 +140,11 @@ type USWStat struct {
 
 // Sw is a subtype of USWStat to make unmarshalling of different controller versions possible.
 type Sw struct {
-	SiteID      string    `json:"site_id"`
+	SiteID      string    `json:"site_id" fake:"{uuid}"`
 	O           string    `json:"o"`
 	Oid         string    `json:"oid"`
 	Sw          string    `json:"sw"`
-	Time        FlexInt   `json:"time"`
+	Time        FlexInt   `json:"time" fake:"{timestamp}"`
 	Datetime    time.Time `json:"datetime"`
 	RxPackets   FlexInt   `json:"rx_packets"`
 	RxBytes     FlexInt   `json:"rx_bytes"`

--- a/uxg.go
+++ b/uxg.go
@@ -18,15 +18,15 @@ type UXG struct {
 	ConnectRequestIP           string                  `json:"connect_request_ip"`
 	ConnectRequestPort         string                  `json:"connect_request_port"`
 	ConnectionNetworkName      string                  `json:"connection_network_name"`
-	ConnectedAt                FlexInt                 `json:"connected_at"`
-	ConsideredLostAt           FlexInt                 `json:"considered_lost_at"`
-	DeviceID                   string                  `json:"device_id"`
+	ConnectedAt                FlexInt                 `json:"connected_at" fake:"{timestamp}"`
+	ConsideredLostAt           FlexInt                 `json:"considered_lost_at" fake:"{timestamp}"`
+	DeviceID                   string                  `json:"device_id" fake:"{uuid}"`
 	DisplayableVersion         string                  `json:"displayable_version"`
-	DownlinkTable              []*DownlinkTable        `json:"downlink_table"`
-	EthernetOverrides          []*EthernetOverrides    `json:"ethernet_overrides"`
-	EthernetTable              []*EthernetTable        `json:"ethernet_table"`
+	DownlinkTable              []*DownlinkTable        `json:"downlink_table" fakesize:"5"`
+	EthernetOverrides          []*EthernetOverrides    `json:"ethernet_overrides" fakesize:"5"`
+	EthernetTable              []*EthernetTable        `json:"ethernet_table" fakesize:"5"`
 	FwCaps                     FlexInt                 `json:"fw_caps"`
-	GeoInfo                    map[string]*GeoInfo     `json:"geo_info"`
+	GeoInfo                    map[string]*GeoInfo     `json:"geo_info" fakesize:"5"`
 	GuestKicks                 FlexInt                 `json:"guest_kicks"`
 	GuestLanNumSta             FlexInt                 `json:"guest-lan-num_sta"`
 	GuestNumSta                FlexInt                 `json:"guest-num_sta"`
@@ -38,10 +38,10 @@ type UXG struct {
 	HasTemperature             FlexBool                `json:"has_temperature"`
 	HashID                     string                  `json:"hash_id"`
 	HwCaps                     FlexInt                 `json:"hw_caps"`
-	ID                         string                  `json:"_id"`
-	IP                         string                  `json:"ip"`
-	InformIP                   string                  `json:"inform_ip"`
-	InformURL                  string                  `json:"inform_url"`
+	ID                         string                  `json:"_id" fake:"{uuid}"`
+	IP                         string                  `json:"ip" fake:"{ipv4address}"`
+	InformIP                   string                  `json:"inform_ip" fake:"{ipv4address}"`
+	InformURL                  string                  `json:"inform_url" fake:"{url}"`
 	Internet                   FlexBool                `json:"internet"`
 	IsAccessPoint              FlexBool                `json:"is_access_point"`
 	KernelVersion              string                  `json:"kernel_version"`
@@ -61,7 +61,7 @@ type UXG struct {
 	LedState                   *LedState               `json:"led_state"`
 	LicenseState               string                  `json:"license_state"`
 	Locating                   FlexBool                `json:"locating"`
-	Mac                        string                  `json:"mac"`
+	Mac                        string                  `json:"mac" fake:"{timestamp}"`
 	ManufacturerID             FlexInt                 `json:"manufacturer_id"`
 	MinInformIntervalSeconds   FlexInt                 `json:"min_inform_interval_seconds"`
 	Model                      string                  `json:"model"`
@@ -87,7 +87,7 @@ type UXG struct {
 	RxBytes                    FlexInt                 `json:"rx_bytes"`
 	Serial                     string                  `json:"serial"`
 	SetupID                    string                  `json:"setup_id"`
-	SiteID                     string                  `json:"site_id"`
+	SiteID                     string                  `json:"site_id" fake:"{uuid}"`
 	SiteName                   string                  `json:"-"`
 	SourceName                 string                  `json:"-"`
 	SpeedtestStatus            SpeedtestStatus         `json:"speedtest-status"`
@@ -141,16 +141,16 @@ type LedState struct {
 // GeoInfo is incuded with certain devices.
 type GeoInfo struct {
 	Accuracy        FlexInt `json:"accuracy"`
-	Address         string  `json:"address"`
-	Asn             FlexInt `json:"asn"`
-	City            string  `json:"city"`
+	Address         string  `json:"address" fake:"{address}"`
+	Asn             FlexInt `json:"asn" fake:"{address}"`
+	City            string  `json:"city" fake:"{city}"`
 	ContinentCode   string  `json:"continent_code"`
 	CountryCode     string  `json:"country_code"`
-	CountryName     string  `json:"country_name"`
+	CountryName     string  `json:"country_name" fake:"{country}"`
 	IspName         string  `json:"isp_name"`
 	IspOrganization string  `json:"isp_organization"`
-	Latitude        FlexInt `json:"latitude"`
-	Longitude       FlexInt `json:"longitude"`
+	Latitude        FlexInt `json:"latitude" fake:"{latitude}"`
+	Longitude       FlexInt `json:"longitude" fake:"{longitude}"`
 	Timezone        string  `json:"timezone"`
 }
 


### PR DESCRIPTION
This is the initial commit which should give us a way to obtain generated data based on the structs. The examples/ is good for understanding real samples, but we would need to stub out some values that don't age well. 


Will be using this for improved testing on `unpoller`.  The `MockUnifi` will leverage gofakeit to generate data instead of requiring a live physical device. An httptest mock server implementation exists as well. 