### PR TITLE
Faker Fixes + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.21"]
+        go: ["stable"]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -33,7 +33,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        go: ["1.21"]
+        go: ["stable"]
         os: [ubuntu-latest]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 'stable'
           cache: true
       - uses: goreleaser/goreleaser-action@v4
         with:

--- a/clients.go
+++ b/clients.go
@@ -100,7 +100,7 @@ type Client struct {
 	LastSeenByUSW    FlexInt  `json:"_last_seen_by_usw"`
 	LatestAssocTime  FlexInt  `json:"latest_assoc_time"`
 	Mac              string   `fake:"{macaddress}"           json:"mac"`
-	Name             string   `json:"name"`
+	Name             string   `fake:"{randomstring:[client-1,client-2,client-3]}" json:"name"`
 	Network          string   `json:"network"`
 	NetworkID        string   `fake:"{uuid}"                 json:"network_id"`
 	Noise            FlexInt  `json:"noise"`

--- a/pdu.go
+++ b/pdu.go
@@ -54,11 +54,11 @@ type PDU struct {
 	Mac                      string           `fake:"{macaddress}"                json:"mac"`
 	ManufacturerID           FlexInt          `json:"manufacturer_id"`
 	MinIfnromIntervalSeconds FlexInt          `json:"min_inform_interval_seconds"`
-	Model                    string           `json:"model"`
+	Model                    string           `fake:"{randomstring:[model-1,model-2,model-3]}" json:"model"`
 	ModelIncompatible        FlexBool         `json:"model_incompatible"`
 	ModelInEOL               FlexBool         `json:"model_in_eol"`
 	ModelInLTS               FlexBool         `json:"model_in_lts"`
-	Name                     string           `json:"name"`
+	Name                     string           `fake:"{randomstring:[pdu-1,pdu-2]}" json:"name"`
 	NextInterval             FlexInt          `json:"next_interval"`
 	NumSta                   FlexInt          `json:"num_sta"`
 	OutletACPowerBudget      FlexInt          `json:"outlet_ac_power_budget"`
@@ -76,43 +76,43 @@ type PDU struct {
 	RollUpgrade              FlexBool         `json:"rollupgrade"`
 	RxBytes                  FlexInt          `json:"rx_bytes"`
 	Satisfaction             FlexInt          `json:"satisfaction"`
-	Serial                   string           `json:"serial"`
+	Serial                   string           `fake:"{uuid}" json:"serial"`
 	SetupID                  string           `fake:"{uuid}"                      json:"setup_id"`
 	site                     *Site
-	SiteID                   string           `fake:"{uuid}"                    json:"site_id"`
-	SiteName                 string           `json:"site_name"`
-	SourceName               string           `json:"source_name"`
-	StartConnectedMillis     FlexInt          `json:"start_connected_millis"`
-	StartDisconnectedMillis  FlexInt          `json:"start_disconnected_millis"`
-	StartupTimestamp         FlexInt          `json:"startup_timestamp"`
-	Stat                     PDUStat          `json:"stat"`
-	State                    FlexInt          `json:"state"`
-	StpPriority              FlexInt          `json:"stp_priority"`
-	StpVersion               string           `fake:"{appversion}"              json:"stp_version"`
-	SwitchCaps               *SwitchCaps      `json:"switch_caps"`
-	SysErrorCaps             FlexInt          `json:"sys_error_caps"`
-	SyslogKey                string           `json:"syslog_key"`
-	SysStats                 SysStats         `json:"sys_stats"`
-	SystemStats              SystemStats      `json:"system-stats"`
-	TotalMaxPower            FlexInt          `json:"total_max_power"`
-	TwoPhaseAdopt            FlexBool         `json:"two_phase_adopt"`
-	TxBytes                  FlexInt          `json:"tx_bytes"`
-	Type                     string           `fake:"{lexify:pdu}"              json:"type"`
-	Unsupported              FlexBool         `json:"unsupported"`
-	UnsupportedReason        FlexInt          `json:"unsupported_reason"`
-	Upgradeable              FlexBool         `json:"upgradable"`
-	Uplink                   Uplink           `json:"uplink"`
-	UplinkDepth              FlexBool         `json:"uplink_depth"`
-	Uptime                   FlexInt          `json:"uptime"`
-	UserNumSta               FlexInt          `json:"user-num_sta"`
-	Version                  string           `fake:"{appversion}"              json:"version"`
+	SiteID                   string      `fake:"{uuid}"                    json:"site_id"`
+	SiteName                 string      `fake:"{company}" json:"site_name"`
+	SourceName               string      `fake:"{animal}" json:"source_name"`
+	StartConnectedMillis     FlexInt     `json:"start_connected_millis"`
+	StartDisconnectedMillis  FlexInt     `json:"start_disconnected_millis"`
+	StartupTimestamp         FlexInt     `json:"startup_timestamp"`
+	Stat                     PDUStat     `json:"stat"`
+	State                    FlexInt     `json:"state"`
+	StpPriority              FlexInt     `json:"stp_priority"`
+	StpVersion               string      `fake:"{appversion}"              json:"stp_version"`
+	SwitchCaps               *SwitchCaps `json:"switch_caps"`
+	SysErrorCaps             FlexInt     `json:"sys_error_caps"`
+	SyslogKey                string      `fake:"{animal}" json:"syslog_key"`
+	SysStats                 SysStats    `json:"sys_stats"`
+	SystemStats              SystemStats `json:"system-stats"`
+	TotalMaxPower            FlexInt     `json:"total_max_power"`
+	TwoPhaseAdopt            FlexBool    `json:"two_phase_adopt"`
+	TxBytes                  FlexInt     `json:"tx_bytes"`
+	Type                     string      `fake:"{lexify:pdu}"              json:"type"`
+	Unsupported              FlexBool    `json:"unsupported"`
+	UnsupportedReason        FlexInt     `json:"unsupported_reason"`
+	Upgradeable              FlexBool    `json:"upgradable"`
+	Uplink                   Uplink      `json:"uplink"`
+	UplinkDepth              FlexBool    `json:"uplink_depth"`
+	Uptime                   FlexInt     `json:"uptime"`
+	UserNumSta               FlexInt     `json:"user-num_sta"`
+	Version                  string      `fake:"{appversion}"              json:"version"`
 }
 
 // OutletOverride hold the PDU outlet override data.
 type OutletOverride struct {
 	CycleEnabled FlexBool `json:"cycle_enabled"`
 	Index        FlexInt  `json:"index"`
-	Name         string   `json:"name"`
+	Name         string   `fake:"{randomstring:[override-1,override-2]}" json:"name"`
 	RelayState   FlexBool `json:"relay_state"`
 }
 
@@ -120,7 +120,7 @@ type OutletOverride struct {
 type OutletTable struct {
 	CycleEnabled      FlexBool `json:"cycle_enabled"`
 	Index             FlexInt  `json:"index"`
-	Name              string   `json:"name"`
+	Name              string   `fake:"{randomstring:[table-1,table-2,table-3]]" json:"name"`
 	OutletCaps        FlexInt  `json:"outlet_caps"`
 	OutletCurrent     FlexInt  `json:"outlet_current"`
 	OutletPower       FlexInt  `json:"outlet_power"`

--- a/site.go
+++ b/site.go
@@ -121,7 +121,7 @@ type Site struct {
 		XputUp                FlexInt  `json:"xput_up,omitempty"`
 	} `fakesize:"5"          json:"health"`
 	ID           string  `fake:"{uuid}"         json:"_id"`
-	Name         string  `fake:"{company}"      json:"name"`
+	Name         string  `fake:"{randomstring:[site-1,site-2]}"      json:"name"`
 	NumNewAlarms FlexInt `json:"num_new_alarms"`
 	SiteName     string  `json:"-"`
 	SourceName   string  `json:"-"`

--- a/types.go
+++ b/types.go
@@ -98,6 +98,22 @@ func init() {
 			return *NewFlexBool(l), nil
 		},
 	})
+
+	gofakeit.AddFuncLookup("tempStatusByName", gofakeit.Info{
+		Category:    "custom",
+		Description: "Configured TempStatusByName",
+		Example:     "TempStatusByName{...}",
+		Output:      "TempStatusByName",
+		Generate: func(r *rand.Rand, m *gofakeit.MapParams, info *gofakeit.Info) (interface{}, error) {
+			return TempStatusByName{
+				"cpu":     NewFlexTemp(float64(r.Int31n(100))),
+				"sys":     NewFlexTemp(float64(r.Int31n(100))),
+				"probe":   NewFlexTemp(float64(r.Int31n(100))),
+				"memory":  NewFlexTemp(float64(r.Int31n(100))),
+				"network": NewFlexTemp(float64(r.Int31n(100))),
+			}, nil
+		},
+	})
 }
 
 var ErrCannotUnmarshalFlexInt = fmt.Errorf("cannot unmarshal to FlexInt")

--- a/uap.go
+++ b/uap.go
@@ -109,7 +109,7 @@ type UAP struct {
 	ModelInEOL                    FlexBool        `json:"model_in_eol"`
 	ModelInLTS                    FlexBool        `json:"model_in_lts"`
 	ModelIncompatible             FlexBool        `json:"model_incompatible"`
-	Name                          string          `json:"name"`
+	Name                          string          `fake:"{randomstring:[uap-1,uap-2]}" json:"name"`
 	NumSta                        FlexInt         `json:"num_sta"`
 	OutdoorModeOverride           string          `json:"outdoor_mode_override"`
 	PortTable                     []Port          `fakesize:"5"                            json:"port_table"`

--- a/usg.go
+++ b/usg.go
@@ -3,8 +3,6 @@ package unifi
 import (
 	"encoding/json"
 	"time"
-
-	"github.com/brianvoe/gofakeit/v6"
 )
 
 // USG represents all the data from the Ubiquiti Controller for a Unifi Security Gateway.
@@ -48,28 +46,28 @@ type USG struct {
 	RxBytes               FlexInt              `json:"rx_bytes"`
 	Serial                string               `json:"serial"`
 	site                  *Site
-	SiteID                string               `fake:"{uuid}"                 json:"site_id"`
-	SiteName              string               `json:"-"`
-	SourceName            string               `json:"-"`
-	SpeedtestStatus       SpeedtestStatus      `json:"speedtest-status"`
-	SpeedtestStatusSaved  FlexBool             `json:"speedtest-status-saved"`
-	Stat                  USGStat              `json:"stat"`
-	State                 FlexInt              `json:"state"`
-	SysStats              SysStats             `json:"sys_stats"`
-	SystemStats           SystemStats          `json:"system-stats"`
-	Temperatures          []Temperature        `fakesize:"5"                  json:"temperatures,omitempty"`
-	TxBytes               FlexInt              `json:"tx_bytes"`
-	Type                  string               `fake:"{lexify:usg}"           json:"type"`
-	Unsupported           FlexBool             `json:"unsupported"`
-	UnsupportedReason     FlexInt              `json:"unsupported_reason"`
-	Upgradable            FlexBool             `json:"upgradable"`
-	Uplink                Uplink               `json:"uplink"`
-	Uptime                FlexInt              `json:"uptime"`
-	UserNumSta            FlexInt              `json:"user-num_sta"`
-	UsgCaps               FlexInt              `json:"usg_caps"`
-	Version               string               `fake:"{appversion}"           json:"version"`
-	Wan1                  Wan                  `json:"wan1"`
-	Wan2                  Wan                  `json:"wan2"`
+	SiteID                string          `fake:"{uuid}"                 json:"site_id"`
+	SiteName              string          `json:"-"`
+	SourceName            string          `json:"-"`
+	SpeedtestStatus       SpeedtestStatus `json:"speedtest-status"`
+	SpeedtestStatusSaved  FlexBool        `json:"speedtest-status-saved"`
+	Stat                  USGStat         `json:"stat"`
+	State                 FlexInt         `json:"state"`
+	SysStats              SysStats        `json:"sys_stats"`
+	SystemStats           SystemStats     `json:"system-stats"`
+	Temperatures          []Temperature   `fakesize:"5"                  json:"temperatures,omitempty"`
+	TxBytes               FlexInt         `json:"tx_bytes"`
+	Type                  string          `fake:"{lexify:usg}"           json:"type"`
+	Unsupported           FlexBool        `json:"unsupported"`
+	UnsupportedReason     FlexInt         `json:"unsupported_reason"`
+	Upgradable            FlexBool        `json:"upgradable"`
+	Uplink                Uplink          `json:"uplink"`
+	Uptime                FlexInt         `json:"uptime"`
+	UserNumSta            FlexInt         `json:"user-num_sta"`
+	UsgCaps               FlexInt         `json:"usg_caps"`
+	Version               string          `fake:"{appversion}"           json:"version"`
+	Wan1                  Wan             `json:"wan1"`
+	Wan2                  Wan             `json:"wan2"`
 }
 
 // Uplink is the Internet connection (or uplink) on a UniFi device.
@@ -184,16 +182,6 @@ type SpeedtestServer struct {
 
 type TempStatusByName map[string]*FlexTemp
 
-func (t TempStatusByName) Fake(faker *gofakeit.Faker) interface{} {
-	return TempStatusByName{
-		"cpu":     NewFlexTemp(float64(faker.Rand.Int63n(100))),
-		"sys":     NewFlexTemp(float64(faker.Rand.Int63n(100))),
-		"probe":   NewFlexTemp(float64(faker.Rand.Int63n(100))),
-		"memory":  NewFlexTemp(float64(faker.Rand.Int63n(100))),
-		"network": NewFlexTemp(float64(faker.Rand.Int63n(100))),
-	}
-}
-
 // SystemStats is system info for a UDM, USG, USW.
 type SystemStats struct {
 	CPU    FlexInt `json:"cpu"`
@@ -201,7 +189,7 @@ type SystemStats struct {
 	Uptime FlexInt `json:"uptime"`
 	// This exists on at least USG4, may others, maybe not.
 	// {"Board (CPU)":"51 C","Board (PHY)":"51 C","CPU":"72 C","PHY":"77 C"}
-	Temps TempStatusByName `json:"temps,omitempty"`
+	Temps TempStatusByName `fake:"{tempStatusByName}" json:"temps,omitempty"`
 }
 
 // SysStats is load info for a UDM, USG, USW.

--- a/usw.go
+++ b/usw.go
@@ -58,13 +58,13 @@ type USW struct {
 	ModelInEOL               FlexBool `json:"model_in_eol"`
 	ModelInLTS               FlexBool `json:"model_in_lts"`
 	ModelIncompatible        FlexBool `json:"model_incompatible"`
-	Name                     string   `json:"name"`
+	Name                     string   `fake:"{animal}" json:"name"`
 	NextInterval             FlexInt  `json:"next_interval"`
 	NumSta                   FlexInt  `json:"num_sta"`
 	OutdoorModeOverride      string   `json:"outdoor_mode_override"`
 	Overheating              FlexBool `json:"overheating"`
 	PortOverrides            []struct {
-		Name       string  `json:"name,omitempty"`
+		Name       string  `fake:"{randomstring:[override-1,override-2]}" json:"name,omitempty"`
 		PoeMode    string  `json:"poe_mode,omitempty"`
 		PortIdx    FlexInt `json:"port_idx"`
 		PortconfID string  `json:"portconf_id"`

--- a/uxg.go
+++ b/uxg.go
@@ -3,89 +3,89 @@ package unifi
 // UXG represents all the data from the Ubiquiti Controller for a UniFi 10Gb Gateway.
 // The UDM shares several structs/type-data with USW and USG.
 type UXG struct {
-	AdoptableWhenUpgraded      FlexBool                `json:"adoptable_when_upgraded"`
-	Adopted                    FlexBool                `fake:"{constFlexBool:true}"          json:"adopted"`
-	AdoptedByClient            string                  `json:"adopted_by_client"`
-	AdoptionCompleted          FlexBool                `json:"adoption_completed"`
-	AnonID                     string                  `json:"anon_id"`
-	Architecture               string                  `json:"architecture"`
-	BoardRev                   FlexInt                 `json:"board_rev"`
-	Bytes                      FlexInt                 `json:"bytes"`
-	Cfgversion                 string                  `json:"cfgversion"`
-	ConfigNetwork              *ConfigNetwork          `json:"config_network"`
-	ConfigNetworkLan           *ConfigNetworkLan       `json:"config_network_lan"`
-	ConnectedAt                FlexInt                 `json:"connected_at"`
-	ConnectionNetworkName      string                  `json:"connection_network_name"`
-	ConnectRequestIP           string                  `json:"connect_request_ip"`
-	ConnectRequestPort         string                  `json:"connect_request_port"`
-	ConsideredLostAt           FlexInt                 `json:"considered_lost_at"`
-	DeviceID                   string                  `fake:"{uuid}"                        json:"device_id"`
-	DisplayableVersion         string                  `json:"displayable_version"`
-	DownlinkTable              []*DownlinkTable        `fakesize:"5"                         json:"downlink_table"`
-	EthernetOverrides          []*EthernetOverrides    `fakesize:"5"                         json:"ethernet_overrides"`
-	EthernetTable              []*EthernetTable        `fakesize:"5"                         json:"ethernet_table"`
-	FwCaps                     FlexInt                 `json:"fw_caps"`
-	GeoInfo                    map[string]*GeoInfo     `fakesize:"5"                         json:"geo_info"`
-	GuestKicks                 FlexInt                 `json:"guest_kicks"`
-	GuestLanNumSta             FlexInt                 `json:"guest-lan-num_sta"`
-	GuestNumSta                FlexInt                 `json:"guest-num_sta"`
-	GuestToken                 string                  `json:"guest_token"`
-	GuestWlanNumSta            FlexInt                 `json:"guest-wlan-num_sta"`
-	HasEth1                    FlexBool                `json:"has_eth1"`
-	HasFan                     FlexBool                `json:"has_fan"`
-	HashID                     string                  `json:"hash_id"`
-	HasSpeaker                 FlexBool                `json:"has_speaker"`
-	HasTemperature             FlexBool                `json:"has_temperature"`
-	HwCaps                     FlexInt                 `json:"hw_caps"`
-	ID                         string                  `fake:"{uuid}"                        json:"_id"`
-	InformIP                   string                  `fake:"{ipv4address}"                 json:"inform_ip"`
-	InformURL                  string                  `fake:"{url}"                         json:"inform_url"`
-	Internet                   FlexBool                `json:"internet"`
-	IP                         string                  `fake:"{ipv4address}"                 json:"ip"`
-	IsAccessPoint              FlexBool                `json:"is_access_point"`
-	KernelVersion              string                  `json:"kernel_version"`
-	KnownCfgversion            string                  `json:"known_cfgversion"`
-	LanNumSta                  FlexInt                 `json:"lan-num_sta"`
-	LastSeen                   FlexInt                 `json:"last_seen"`
-	LastWanIP                  string                  `json:"last_wan_ip"`
-	LcmBrightness              FlexInt                 `json:"lcm_brightness"`
-	LcmBrightnessOverride      FlexBool                `json:"lcm_brightness_override"`
-	LcmIdleTimeoutOverride     FlexBool                `json:"lcm_idle_timeout_override"`
-	LcmNightModeBegins         string                  `json:"lcm_night_mode_begins"`
-	LcmNightModeEnabled        FlexBool                `json:"lcm_night_mode_enabled"`
-	LcmNightModeEnds           string                  `json:"lcm_night_mode_ends"`
-	LedOverride                string                  `json:"led_override"`
-	LedOverrideColor           string                  `json:"led_override_color"`
-	LedOverrideColorBrightness FlexInt                 `json:"led_override_color_brightness"`
-	LedState                   *LedState               `json:"led_state"`
-	LicenseState               string                  `json:"license_state"`
-	Locating                   FlexBool                `fake:"{constFlexBool:false}"         json:"locating"`
-	Mac                        string                  `fake:"{macaddress}"                  json:"mac"`
-	ManufacturerID             FlexInt                 `json:"manufacturer_id"`
-	MinInformIntervalSeconds   FlexInt                 `json:"min_inform_interval_seconds"`
-	Model                      string                  `json:"model"`
-	ModelIncompatible          FlexBool                `json:"model_incompatible"`
-	ModelInEol                 FlexBool                `json:"model_in_eol"`
-	ModelInLts                 FlexBool                `json:"model_in_lts"`
-	Name                       string                  `json:"name"`
-	NetworkTable               NetworkTable            `json:"network_table"`
-	NextHeartbeatAt            FlexInt                 `json:"next_heartbeat_at"`
-	NextInterval               FlexInt                 `json:"next_interval"`
-	NumDesktop                 FlexInt                 `json:"num_desktop"`
-	NumHandheld                FlexInt                 `json:"num_handheld"`
-	NumMobile                  FlexInt                 `json:"num_mobile"`
-	NumSta                     FlexInt                 `json:"num_sta"`
-	OutdoorModeOverride        string                  `json:"outdoor_mode_override"`
-	OutdoorPowerCycleEnabled   FlexBool                `json:"outlet_power_cycle_enabled"`
-	Overheating                FlexBool                `json:"overheating"`
-	PortTable                  []Port                  `json:"port_table"`
-	ProvisionedAt              FlexInt                 `json:"provisioned_at"`
-	RequiredVersion            string                  `json:"required_version"`
-	RollUpgrade                FlexBool                `json:"rollupgrade"`
-	RulesetInterfaces          interface{}             `json:"ruleset_interfaces"`
-	RxBytes                    FlexInt                 `json:"rx_bytes"`
-	Serial                     string                  `json:"serial"`
-	SetupID                    string                  `json:"setup_id"`
+	AdoptableWhenUpgraded      FlexBool             `json:"adoptable_when_upgraded"`
+	Adopted                    FlexBool             `fake:"{constFlexBool:true}"          json:"adopted"`
+	AdoptedByClient            string               `json:"adopted_by_client"`
+	AdoptionCompleted          FlexBool             `json:"adoption_completed"`
+	AnonID                     string               `json:"anon_id"`
+	Architecture               string               `json:"architecture"`
+	BoardRev                   FlexInt              `json:"board_rev"`
+	Bytes                      FlexInt              `json:"bytes"`
+	Cfgversion                 string               `json:"cfgversion"`
+	ConfigNetwork              *ConfigNetwork       `json:"config_network"`
+	ConfigNetworkLan           *ConfigNetworkLan    `json:"config_network_lan"`
+	ConnectedAt                FlexInt              `json:"connected_at"`
+	ConnectionNetworkName      string               `json:"connection_network_name"`
+	ConnectRequestIP           string               `json:"connect_request_ip"`
+	ConnectRequestPort         string               `json:"connect_request_port"`
+	ConsideredLostAt           FlexInt              `json:"considered_lost_at"`
+	DeviceID                   string               `fake:"{uuid}"                        json:"device_id"`
+	DisplayableVersion         string               `json:"displayable_version"`
+	DownlinkTable              []*DownlinkTable     `fakesize:"5"                         json:"downlink_table"`
+	EthernetOverrides          []*EthernetOverrides `fakesize:"5"                         json:"ethernet_overrides"`
+	EthernetTable              []*EthernetTable     `fakesize:"5"                         json:"ethernet_table"`
+	FwCaps                     FlexInt              `json:"fw_caps"`
+	GeoInfo                    map[string]*GeoInfo  `fakesize:"5"                         json:"geo_info"`
+	GuestKicks                 FlexInt              `json:"guest_kicks"`
+	GuestLanNumSta             FlexInt              `json:"guest-lan-num_sta"`
+	GuestNumSta                FlexInt              `json:"guest-num_sta"`
+	GuestToken                 string               `json:"guest_token"`
+	GuestWlanNumSta            FlexInt              `json:"guest-wlan-num_sta"`
+	HasEth1                    FlexBool             `json:"has_eth1"`
+	HasFan                     FlexBool             `json:"has_fan"`
+	HashID                     string               `json:"hash_id"`
+	HasSpeaker                 FlexBool             `json:"has_speaker"`
+	HasTemperature             FlexBool             `json:"has_temperature"`
+	HwCaps                     FlexInt              `json:"hw_caps"`
+	ID                         string               `fake:"{uuid}"                        json:"_id"`
+	InformIP                   string               `fake:"{ipv4address}"                 json:"inform_ip"`
+	InformURL                  string               `fake:"{url}"                         json:"inform_url"`
+	Internet                   FlexBool             `json:"internet"`
+	IP                         string               `fake:"{ipv4address}"                 json:"ip"`
+	IsAccessPoint              FlexBool             `json:"is_access_point"`
+	KernelVersion              string               `json:"kernel_version"`
+	KnownCfgversion            string               `json:"known_cfgversion"`
+	LanNumSta                  FlexInt              `json:"lan-num_sta"`
+	LastSeen                   FlexInt              `json:"last_seen"`
+	LastWanIP                  string               `json:"last_wan_ip"`
+	LcmBrightness              FlexInt              `json:"lcm_brightness"`
+	LcmBrightnessOverride      FlexBool             `json:"lcm_brightness_override"`
+	LcmIdleTimeoutOverride     FlexBool             `json:"lcm_idle_timeout_override"`
+	LcmNightModeBegins         string               `json:"lcm_night_mode_begins"`
+	LcmNightModeEnabled        FlexBool             `json:"lcm_night_mode_enabled"`
+	LcmNightModeEnds           string               `json:"lcm_night_mode_ends"`
+	LedOverride                string               `json:"led_override"`
+	LedOverrideColor           string               `json:"led_override_color"`
+	LedOverrideColorBrightness FlexInt              `json:"led_override_color_brightness"`
+	LedState                   *LedState            `json:"led_state"`
+	LicenseState               string               `json:"license_state"`
+	Locating                   FlexBool             `fake:"{constFlexBool:false}"         json:"locating"`
+	Mac                        string               `fake:"{macaddress}"                  json:"mac"`
+	ManufacturerID             FlexInt              `json:"manufacturer_id"`
+	MinInformIntervalSeconds   FlexInt              `json:"min_inform_interval_seconds"`
+	Model                      string               `json:"model"`
+	ModelIncompatible          FlexBool             `json:"model_incompatible"`
+	ModelInEol                 FlexBool             `json:"model_in_eol"`
+	ModelInLts                 FlexBool             `json:"model_in_lts"`
+	Name                       string               `fake:"{animal}" json:"name"`
+	NetworkTable               NetworkTable         `json:"network_table"`
+	NextHeartbeatAt            FlexInt              `json:"next_heartbeat_at"`
+	NextInterval               FlexInt              `json:"next_interval"`
+	NumDesktop                 FlexInt              `json:"num_desktop"`
+	NumHandheld                FlexInt              `json:"num_handheld"`
+	NumMobile                  FlexInt              `json:"num_mobile"`
+	NumSta                     FlexInt              `json:"num_sta"`
+	OutdoorModeOverride        string               `json:"outdoor_mode_override"`
+	OutdoorPowerCycleEnabled   FlexBool             `json:"outlet_power_cycle_enabled"`
+	Overheating                FlexBool             `json:"overheating"`
+	PortTable                  []Port               `json:"port_table"`
+	ProvisionedAt              FlexInt              `json:"provisioned_at"`
+	RequiredVersion            string               `json:"required_version"`
+	RollUpgrade                FlexBool             `json:"rollupgrade"`
+	RulesetInterfaces          interface{}          `json:"ruleset_interfaces"`
+	RxBytes                    FlexInt              `json:"rx_bytes"`
+	Serial                     string               `json:"serial"`
+	SetupID                    string               `json:"setup_id"`
 	site                       *Site
 	SiteID                     string                  `fake:"{uuid}"                    json:"site_id"`
 	SiteName                   string                  `json:"-"`


### PR DESCRIPTION
- Fix some fake mocks that provide more stability for integration testing. Note something changed in gofakeit where the alias type was no longer used, so had to use the custom func definition for it instead and this fixed the integration tests locally in unpoller/unpoller
- update dependabot to auto update actions
- move to general "stable" version of go