### PR TITLE
Get Client History

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -74,6 +74,7 @@ func (u *Unifi) GetClientHistory(sites []*Site, opts *ClientHistoryOpts) ([]Clie
 	params.Add("onlyNonBlocked", fmt.Sprint(opts.OnlyNonBlocked))
 	params.Add("includeUnifiDevices", fmt.Sprint(opts.IncludeUnifiDevices))
 	params.Add("withinHours", fmt.Sprint(opts.WithinHours))
+	paramStr := params.Encode()
 
 	data := make([]ClientHistory, 0)
 
@@ -82,8 +83,8 @@ func (u *Unifi) GetClientHistory(sites []*Site, opts *ClientHistoryOpts) ([]Clie
 
 		u.DebugLog("Polling Controller, retreiving UniFi Client History, site %s ", site.SiteName)
 
-		clientPath := fmt.Sprintf(APIClientHistoryPath, site.Name)
-		if err := u.GetData(clientPath, &response, params.Encode()); err != nil {
+		clientPath := fmt.Sprintf(APIClientHistoryPath, site.Name, paramStr)
+		if err := u.GetData(clientPath, &response, ""); err != nil {
 			return nil, err
 		}
 

--- a/clients.go
+++ b/clients.go
@@ -66,7 +66,6 @@ func (u *Unifi) GetClientsDPI(sites []*Site) ([]*DPITable, error) {
 
 // GetClientHistory pulls client history data from the controller.
 func (u *Unifi) GetClientHistory(sites []*Site, opts *ClientHistoryOpts) ([]ClientHistory, error) {
-	// TODO: could use external library to convert struct to url query params ?
 	if opts == nil {
 		opts = NewClientHistoryOpts()
 	}
@@ -202,19 +201,20 @@ type ClientHistory struct {
 		HasOverride FlexBool `json:"has_override"`
 	} `json:"fingerprint"`
 	FirstSeen                     FlexInt      `json:"first_seen"`
-	Hostname                      string       `json:"hostname,omitempty"`
-	ID                            string       `json:"id"`
+	Hostname                      string       `fake:"noun" json:"hostname,omitempty"`
+	ID                            string       `fake:"{uuid}" json:"id"`
 	IsAllowedInVisualProgramming  FlexBool     `json:"is_allowed_in_visual_programming"`
 	IsGuest                       FlexBool     `json:"is_guest"`
 	IsMlo                         FlexBool     `json:"is_mlo"`
 	IsWired                       FlexBool     `json:"is_wired"`
-	LastIP                        string       `json:"last_ip"`
+	LastIP                        string       `fake:"ipv4address" json:"last_ip"`
 	LastRadio                     string       `json:"last_radio"`
 	LastSeen                      FlexInt      `json:"last_seen"`
-	LastUplinkMac                 string       `json:"last_uplink_mac"`
+	LastUplinkMac                 string       `fake:"macaddress" json:"last_uplink_mac"`
 	LastUplinkName                string       `json:"last_uplink_name"`
 	LocalDNSRecordEnabled         FlexBool     `json:"local_dns_record_enabled"`
-	Mac                           string       `json:"mac"`
+	Mac                           string       `fake:"macaddress" json:"mac"`
+	Note                          string       `json:"note"`
 	Noted                         FlexBool     `json:"noted"`
 	Oui                           string       `json:"oui"`
 	SiteID                        string       `json:"site_id"`
@@ -222,7 +222,7 @@ type ClientHistory struct {
 	Tags                          []FlexString `json:"tags"`
 	Type                          string       `json:"type"`
 	UnifiDevice                   FlexBool     `json:"unifi_device"`
-	UplinkMac                     string       `json:"uplink_mac"`
+	UplinkMac                     string       `fake:"macaddress" json:"uplink_mac"`
 	UseFixedip                    FlexBool     `json:"use_fixedip"`
 	UserID                        string       `json:"user_id"`
 	UsergroupID                   string       `json:"usergroup_id"`

--- a/clients_test.go
+++ b/clients_test.go
@@ -1,0 +1,1 @@
+package unifi

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -134,6 +134,26 @@ func (m *MockUnifi) GetClientsDPI(_ []*unifi.Site) ([]*unifi.DPITable, error) {
 	return results, nil
 }
 
+// GetClientHistory returns a response full of client history from the UniFi Controller
+func (m *MockUnifi) GetClientHistory(_ []*unifi.Site, _ *unifi.ClientHistoryOpts) ([]unifi.ClientHistory, error) {
+	// TODO : add logic to generate data based on ClientHistoryOpts
+	results := make([]unifi.ClientHistory, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.ClientHistory
+
+		err := gofakeit.Struct(&a)
+
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = a
+	}
+
+	return results, nil
+}
+
 // GetDevices returns a response full of devices' data from the UniFi Controller.
 func (m *MockUnifi) GetDevices(_ []*unifi.Site) (*unifi.Devices, error) {
 	var d unifi.Devices

--- a/types.go
+++ b/types.go
@@ -223,6 +223,8 @@ type UnifiClient interface { //nolint: revive
 	GetAnomaliesSite(site *Site, timeRange ...time.Time) ([]*Anomaly, error)
 	// GetClients returns a response full of clients' data from the UniFi Controller.
 	GetClients(sites []*Site) ([]*Client, error)
+	// GetClients returns a response full of client history data from the UniFi Controller.
+	GetClientHistory(sites []*Site, opts *ClientHistoryOpts) ([]ClientHistory, error)
 	// GetClientsDPI garners dpi data for clients.
 	GetClientsDPI(sites []*Site) ([]*DPITable, error)
 	// GetDevices returns a response full of devices' data from the UniFi Controller.

--- a/types.go
+++ b/types.go
@@ -136,6 +136,8 @@ const (
 	APIClientDPI string = "/api/s/%s/stat/stadpi"
 	// APIClientPath is Unifi Clients API Path.
 	APIClientPath string = "/api/s/%s/stat/sta"
+	// APIClientHistoryPath is Unifi Clients History API Path.
+	APIClientHistoryPath string = "/v2/api/s/%s/stat/sta"
 	// APIAllUserPath is Unifi Insight all previous Clients API Path.
 	APIAllUserPath string = "/api/s/%s/stat/alluser"
 	// APINetworkPath is where we get data about Unifi networks.

--- a/types.go
+++ b/types.go
@@ -137,7 +137,7 @@ const (
 	// APIClientPath is Unifi Clients API Path.
 	APIClientPath string = "/api/s/%s/stat/sta"
 	// APIClientHistoryPath is Unifi Clients History API Path.
-	APIClientHistoryPath string = "/v2/api/s/%s/stat/sta"
+	APIClientHistoryPath string = "/v2/api/site/%s/clients/history?%s"
 	// APIAllUserPath is Unifi Insight all previous Clients API Path.
 	APIAllUserPath string = "/api/s/%s/stat/alluser"
 	// APINetworkPath is where we get data about Unifi networks.


### PR DESCRIPTION
Hello!

I wanted an easy way to pull the client history which included offline devices.
The latest version of the UniFi Controller uses the following URL to pull device history, _/proxy/network/v2/api/site/%s/clients/history?%s_ where the first string substitution is the site name and the second substitution are the following query parameters:

```
type ClientHistoryOpts struct {
	OnlyNonBlocked      bool
	IncludeUnifiDevices bool
	WithinHours         int // 0 for all time
}
```

I have added the required URL and function stub in the types.go and the implementation in the clients.go source files. I started to write the test, but do need some advice on how I should proceed with the test.

I am also a little confused if the client mock is being used anywhere, but added the necessary implementation in the mock files as well.

Thanks!