### PR TITLE
Fix UBB RadioTable and VapTable type definitions

### DIFF
--- a/ubb.go
+++ b/ubb.go
@@ -221,7 +221,7 @@ type UBB struct {
 	P2PStats                   *P2PStats         `json:"p2p_stats"`
 	PeerUbb                    *UBB              `fake:"-"                             json:"peer_ubb"`
 	ProvisionedAt              FlexInt           `json:"provisioned_at"`
-	RadioTable                 []RadioTable      `fakesize:"1"                         json:"radio_table"`
+	RadioTable                 RadioTable        `json:"radio_table"`
 	RadioTableStats            RadioTableStats   `json:"radio_table_stats"`
 	RebootDuration             FlexInt           `json:"reboot_duration"`
 	RequiredVersion            string            `json:"required_version"`
@@ -264,7 +264,7 @@ type UBB struct {
 	Uptime0                    FlexInt           `json:"_uptime"`
 	UserNumSta                 FlexInt           `json:"user-num_sta"`
 	UserWlanNumSta             FlexInt           `json:"user-wlan-num_sta"`
-	VapTable                   []VapTable        `fakesize:"1"                         json:"vap_table"`
+	VapTable                   VapTable          `json:"vap_table"`
 	Version                    string            `json:"version"`
 	WifiCaps                   FlexInt           `json:"wifi_caps"`
 	WlangroupIDNa              string            `json:"wlangroup_id_na"`


### PR DESCRIPTION
The UBB struct incorrectly defined RadioTable and VapTable as slices of slices ([]RadioTable and []VapTable), when they should be direct type references (RadioTable and VapTable), since RadioTable and VapTable are already defined as slice types ([]struct).

This fixes JSON unmarshaling errors when parsing UBB device data from the UniFi controller API.

Fixes: unpoller/unpoller#409