### PR TITLE
fix: resolve golangci-lint issues

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -205,20 +205,20 @@ type ClientHistory struct {
 	} `json:"fingerprint"`
 	FirstSeen                     FlexInt      `json:"first_seen"`
 	FixedApEnabled                FlexBool     `json:"fixed_ap_enabled,omitempty"`
-	Hostname                      string       `fake:"noun" json:"hostname,omitempty"`
-	ID                            string       `fake:"{uuid}" json:"id"`
+	Hostname                      string       `fake:"noun"                                  json:"hostname,omitempty"`
+	ID                            string       `fake:"{uuid}"                                json:"id"`
 	IsAllowedInVisualProgramming  FlexBool     `json:"is_allowed_in_visual_programming"`
 	IsGuest                       FlexBool     `json:"is_guest"`
 	IsMlo                         FlexBool     `json:"is_mlo"`
 	IsWired                       FlexBool     `json:"is_wired"`
-	LastIP                        string       `fake:"ipv4address" json:"last_ip"`
+	LastIP                        string       `fake:"ipv4address"                           json:"last_ip"`
 	LastRadio                     string       `json:"last_radio"`
 	LastSeen                      FlexInt      `json:"last_seen"`
-	LastUplinkMac                 string       `fake:"macaddress" json:"last_uplink_mac"`
+	LastUplinkMac                 string       `fake:"macaddress"                            json:"last_uplink_mac"`
 	LastUplinkName                string       `json:"last_uplink_name"`
 	LocalDNSRecord                string       `json:"local_dns_record,omitempty"`
 	LocalDNSRecordEnabled         FlexBool     `json:"local_dns_record_enabled"`
-	Mac                           string       `fake:"macaddress" json:"mac"`
+	Mac                           string       `fake:"macaddress"                            json:"mac"`
 	Note                          string       `json:"note"`
 	Noted                         FlexBool     `json:"noted"`
 	Oui                           string       `json:"oui"`
@@ -227,7 +227,7 @@ type ClientHistory struct {
 	Tags                          []FlexString `json:"tags"`
 	Type                          string       `json:"type"`
 	UnifiDevice                   FlexBool     `json:"unifi_device"`
-	UplinkMac                     string       `fake:"macaddress" json:"uplink_mac"`
+	UplinkMac                     string       `fake:"macaddress"                            json:"uplink_mac"`
 	UseFixedip                    FlexBool     `json:"use_fixedip"`
 	UserID                        string       `json:"user_id"`
 	UsergroupID                   string       `json:"usergroup_id"`
@@ -265,6 +265,7 @@ func NewClientHistoryOpts() *ClientHistoryOpts {
 // returns a pointer to the ClientHistoryOpts struct to allow for chaining of the options methods
 func (c *ClientHistoryOpts) SetOnlyNonBlocked(onlyNonBlocked bool) *ClientHistoryOpts {
 	c.OnlyNonBlocked = onlyNonBlocked
+
 	return c
 }
 
@@ -272,6 +273,7 @@ func (c *ClientHistoryOpts) SetOnlyNonBlocked(onlyNonBlocked bool) *ClientHistor
 // returns a pointer to the ClientHistoryOpts struct to allow for chaining of the options methods
 func (c *ClientHistoryOpts) SetIncludeUnifiDevices(includeUnifiDevices bool) *ClientHistoryOpts {
 	c.IncludeUnifiDevices = includeUnifiDevices
+
 	return c
 }
 
@@ -279,5 +281,6 @@ func (c *ClientHistoryOpts) SetIncludeUnifiDevices(includeUnifiDevices bool) *Cl
 // returns a pointer to the ClientHistoryOpts struct to allow for chaining of the options methods
 func (c *ClientHistoryOpts) SetWithinHours(withinHours uint) *ClientHistoryOpts {
 	c.WithinHours = withinHours
+
 	return c
 }

--- a/clients_test.go
+++ b/clients_test.go
@@ -27,6 +27,7 @@ func TestParseClientHistory(t *testing.T) {
 
 func TestClientHistoryOpts(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		actual   *unifi.ClientHistoryOpts
 		expected *unifi.ClientHistoryOpts

--- a/system_log.go
+++ b/system_log.go
@@ -79,6 +79,7 @@ func DefaultSystemLogRequest(hours time.Duration) *SystemLogRequest {
 	}
 
 	now := time.Now()
+
 	return &SystemLogRequest{
 		Severities:    []string{"LOW", "MEDIUM", "HIGH", "VERY_HIGH"},
 		TimestampFrom: now.Add(-hours).UnixMilli(),
@@ -118,6 +119,7 @@ func (u *Unifi) GetSiteSystemLog(site *Site, req *SystemLogRequest) ([]*SystemLo
 	u.DebugLog("Polling Controller for System Log (v2), site %s", site.SiteName)
 
 	var allEntries []*SystemLogEntry
+
 	currentPage := req.PageNumber
 
 	// Paginate through all results
@@ -154,6 +156,7 @@ func (u *Unifi) GetSiteSystemLog(site *Site, req *SystemLogRequest) ([]*SystemLo
 		// Safety limit to prevent infinite loops
 		if currentPage > 100 {
 			u.DebugLog("System log pagination limit reached (100 pages)")
+
 			break
 		}
 	}
@@ -203,8 +206,10 @@ func (s *SystemLogEntry) GetClientName() string {
 		if client.Name != "" {
 			return client.Name
 		}
+
 		return client.Hostname
 	}
+
 	return ""
 }
 
@@ -213,6 +218,7 @@ func (s *SystemLogEntry) GetClientMAC() string {
 	if client, ok := s.Parameters["CLIENT"]; ok {
 		return client.ID
 	}
+
 	return ""
 }
 
@@ -221,9 +227,11 @@ func (s *SystemLogEntry) GetDeviceName() string {
 	if device, ok := s.Parameters["DEVICE"]; ok {
 		return device.Name
 	}
+
 	if device, ok := s.Parameters["DEVICE_TO"]; ok {
 		return device.Name
 	}
+
 	return ""
 }
 


### PR DESCRIPTION
This PR fixes 18 linting issues reported by golangci-lint:

- **9 nlreturn issues**: Added blank lines before return/break statements
- **6 tagalign issues**: Aligned struct tags in `ClientHistory` struct
- **3 wsl_v5 issues**: Added missing whitespace above assignments and if statements

All issues were auto-fixed by running `golangci-lint run ./...` with `fix: true` in the config.