### PR TITLE
Add DeviceName field to Alarm struct

### DIFF
--- a/alarms.go
+++ b/alarms.go
@@ -52,6 +52,7 @@ type Alarm struct {
 	USGIPCountry          string     `json:"usgipCountry"`
 	USGIPGeo              IPGeo      `json:"srcipGeo,omitempty"`
 	UniqueAlertID         string     `json:"unique_alertid"`
+	DeviceName            string     `json:"device_name,omitempty"`
 }
 
 // GetAlarms returns Alarms for a list of Sites.


### PR DESCRIPTION
## Summary
- Add `DeviceName` field to `Alarm` struct for better device identification in logs

## Details

This PR adds a new `DeviceName` field to the `Alarm` struct that can be populated by UniFi Poller to provide human-readable device names in alarm logs.

### Changes
- Added `DeviceName string` field with `json:"device_name,omitempty"` tag to the `Alarm` struct

### Motivation

Currently, alarms in Loki logs only show MAC addresses (e.g., "AP[fc:ec:da:89:a6:91] was disconnected"), making it difficult to quickly identify which device triggered an alarm. This field allows UniFi Poller to enrich alarms with device names during collection.

### Related

This is part of the fix for unpoller/unpoller#415. A corresponding PR in the unpoller repository will populate this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)