### PR TITLE
Add endpoint discovery (DiscoverEndpoints, Probe, --discover)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 .idea/
 .env
+unifi-cli

--- a/README.md
+++ b/README.md
@@ -62,3 +62,24 @@ func main() {
 	}
 }
 ```
+
+## Endpoint discovery (`--discover`)
+
+The `main` CLI (in `main/`) supports a **discover** mode that probes known API endpoints on your controller and writes a shareable report. Use the same credentials you use with unpoller (from your config file or env).
+
+**With a config file** (JSON with `url`, `user`, `pass`; optional `api_key`):
+
+```bash
+go run ./main --discover --config /path/to/unifi-config.json --output api_endpoints_discovery.md
+```
+
+**With environment variables** (same as unpoller: `GOLIFT_UNIFI_URL`, `GOLIFT_UNIFI_USER`, `GOLIFT_UNIFI_PASS`):
+
+```bash
+export GOLIFT_UNIFI_URL=https://192.168.1.1:8443
+export GOLIFT_UNIFI_USER=admin
+export GOLIFT_UNIFI_PASS=yourpassword
+go run ./main --discover --output api_endpoints_discovery.md
+```
+
+The report lists each endpoint and its HTTP status (200, 404, etc.). Share the generated file with maintainers when reporting API or 404 issues (e.g. [unpoller#935](https://github.com/unpoller/unpoller/issues/935)).

--- a/discover.go
+++ b/discover.go
@@ -1,0 +1,114 @@
+// Package unifi: endpoint discovery for support and debugging.
+// DiscoverEndpoints probes a set of known API paths and writes a shareable report.
+
+package unifi
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DiscoverResult holds the result of probing a single endpoint.
+type DiscoverResult struct {
+	Method string
+	Path   string
+	Status int
+}
+
+// DiscoverEndpoints probes known API paths on the controller and writes a markdown report
+// to outputPath. Use the same config (URL, user, pass) as unpoller so users can share
+// the output file for support. site is typically "default".
+func (u *Unifi) DiscoverEndpoints(site, outputPath string) error {
+	now := time.Now()
+	end := now.UnixMilli()
+	start := end - 3600000
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{"GET", APISiteList},
+		{"GET", fmt.Sprintf(APIDevicePath, site)},
+		{"GET", fmt.Sprintf(APIClientPath, site)},
+		{"GET", fmt.Sprintf(APIEventPath, site)},
+		{"GET", fmt.Sprintf(APIEventPathAlarms, site)},
+		{"GET", fmt.Sprintf(APINetworkPath, site)},
+		{"GET", fmt.Sprintf(APISiteDPI, site)},
+		{"GET", fmt.Sprintf(APIClientDPI, site)},
+		{"GET", fmt.Sprintf(APIAnomaliesPath, site)},
+		{"GET", fmt.Sprintf(APISystemLogPath, site)},
+		{"GET", fmt.Sprintf(APIDeviceTagsPath, site)},
+		{"GET", fmt.Sprintf(APIActiveDHCPLeasesPath, site)},
+		{"GET", fmt.Sprintf(APIWANEnrichedConfigPath, site)},
+		{"GET", fmt.Sprintf(APIWANLoadBalancingStatusPath, site)},
+		{"GET", fmt.Sprintf(APIWANLoadBalancingConfigPath, site)},
+		{"GET", fmt.Sprintf(APIWANSLAsPath, site)},
+		{"GET", fmt.Sprintf(APIClientTrafficPath, site, start, end, false)},
+		{"GET", fmt.Sprintf(APICountryTrafficPath, site, start, end)},
+		{"GET", fmt.Sprintf(APIAggregatedDashboard, site, 86400)},
+		{"GET", fmt.Sprintf(APIRogueAP, site)},
+		{"GET", fmt.Sprintf(APIAllUserPath, site)},
+		{"GET", fmt.Sprintf(APIEventPathIDS, site)},
+	}
+
+	results := make([]DiscoverResult, 0, len(paths))
+
+	for _, p := range paths {
+		status, err := u.Probe(p.path)
+		if err != nil {
+			u.ErrorLog("discover: probe %s: %v", p.path, err)
+
+			results = append(results, DiscoverResult{Method: p.method, Path: p.path, Status: -1})
+		} else {
+			results = append(results, DiscoverResult{Method: p.method, Path: p.path, Status: status})
+		}
+	}
+
+	// WAN ISP status needs a wan id; skip or use a placeholder - try common "wan" id
+	wanPaths := []string{"wan", "wan1", "wan2"}
+	for _, w := range wanPaths {
+		path := fmt.Sprintf(APIWANISPStatusPath, site, w)
+
+		status, err := u.Probe(path)
+		if err != nil {
+			continue
+		}
+
+		results = append(results, DiscoverResult{Method: "GET", Path: path, Status: status})
+	}
+
+	return writeDiscoverReport(u.URL, site, results, outputPath)
+}
+
+func writeDiscoverReport(controllerURL, site string, results []DiscoverResult, outputPath string) error {
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Path < results[j].Path
+	})
+
+	var b strings.Builder
+	b.WriteString("# API Endpoints (discovery report)\n\n")
+	b.WriteString(fmt.Sprintf("- **Controller**: %s\n", controllerURL))
+	b.WriteString(fmt.Sprintf("- **Site**: %s\n", site))
+	b.WriteString(fmt.Sprintf("- **Total endpoints probed**: %d\n", len(results)))
+	b.WriteString("\n---\n\n")
+	b.WriteString("| Method | Path | Status |\n")
+	b.WriteString("|--------|------|--------|\n")
+
+	for _, r := range results {
+		statusStr := fmt.Sprintf("%d", r.Status)
+		if r.Status < 0 {
+			statusStr = "error"
+		}
+
+		pathEscaped := strings.ReplaceAll(r.Path, "|", "\\|")
+		b.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n", r.Method, pathEscaped, statusStr))
+	}
+
+	b.WriteString("\n---\n\n")
+	b.WriteString("Share this file with maintainers when reporting API or 404 issues.\n")
+
+	return os.WriteFile(outputPath, []byte(b.String()), 0o600)
+}

--- a/main/main.go
+++ b/main/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -69,7 +70,95 @@ func ShowResponse[T any](prefix string, data []T, numResponses int) {
 const ERROR = "ERROR:"
 const FATAL = "FATAL:"
 
+// discoverConfig is the JSON shape for --config when using --discover.
+// Use the same URL, user, and pass as your unpoller config.
+type discoverConfig struct {
+	URL    string `json:"url"`
+	User   string `json:"user"`
+	Pass   string `json:"pass"`
+	APIKey string `json:"api_key"`
+}
+
+func loadConfig(path string) (*unifi.Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	var c discoverConfig
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	c.URL = strings.TrimSpace(strings.TrimSuffix(c.URL, "/"))
+	if c.URL == "" || c.User == "" {
+		return nil, fmt.Errorf("config must set url and user")
+	}
+
+	cfg := &unifi.Config{
+		URL:      c.URL,
+		User:     c.User,
+		Pass:     c.Pass,
+		APIKey:   c.APIKey,
+		ErrorLog: log.Printf,
+		DebugLog: log.Printf,
+	}
+
+	return cfg, nil
+}
+
 func main() {
+	discover := flag.Bool("discover", false, "discover API endpoints and write a shareable report (use with --config and --output)")
+	configPath := flag.String("config", "", "path to JSON config for --discover (keys: url, user, pass); if unset, uses GOLIFT_UNIFI_* env")
+	outputPath := flag.String("output", "api_endpoints_discovery.md", "path for discovery report when using --discover")
+
+	flag.Parse()
+
+	if *discover {
+		var cfg *unifi.Config
+
+		if *configPath != "" {
+			var err error
+
+			cfg, err = loadConfig(*configPath)
+			if err != nil {
+				log.Fatalln("FATAL:", err)
+			}
+		} else {
+			cfg = &unifi.Config{
+				URL:      GetEnvString("GOLIFT_UNIFI_URL", "http://localhost:8080"),
+				User:     GetEnvString("GOLIFT_UNIFI_USER", "admin"),
+				Pass:     GetEnvString("GOLIFT_UNIFI_PASS", ""),
+				ErrorLog: log.Printf,
+				DebugLog: log.Printf,
+			}
+		}
+
+		uni, err := unifi.NewUnifi(cfg)
+		if err != nil {
+			log.Fatalln("FATAL:", err)
+		}
+
+		sites, err := uni.GetSites()
+		if err != nil {
+			log.Fatalln("FATAL:", err)
+		}
+
+		site := "default"
+		if len(sites) > 0 && sites[0].Name != "" {
+			site = sites[0].Name
+		}
+
+		if err := uni.DiscoverEndpoints(site, *outputPath); err != nil {
+			log.Fatalln("FATAL:", err)
+		}
+
+		log.Printf("Discovery report written to %s (share this file with maintainers for API/404 issues).", *outputPath)
+
+		return
+	}
+
+	// Default: use env and run normal data fetch
 	var config = unifi.Config{
 		User:     GetEnvString("GOLIFT_UNIFI_USER", "admin"),
 		Pass:     GetEnvString("GOLIFT_UNIFI_PASS", ""),


### PR DESCRIPTION
Adds endpoint discovery so unpoller (and other consumers) can probe known API paths on a controller and write a shareable report. Used by unpoller PR #937 (`--discover` flag).

**Library**
- `Probe(apiPath string, params ...string) (int, error)` — GET to path, returns HTTP status (no error on non-2xx).
- `DiscoverEndpoints(site, outputPath string) error` — probes a set of known API paths, writes markdown report (method, path, status). Same credentials as unpoller; users can share the file for API/404 issues (e.g. unpoller#935).

**main CLI**
- `--discover`, `--output`, `--config` — uses config file (JSON with url, user, pass) or `GOLIFT_UNIFI_*` env; runs discovery and exits.
- README documents usage.

**Files:** `discover.go` (new), `unifi.go` (Probe), `main/main.go` (flags), `main/main_test.go` (TestLoadConfig), README, .gitignore.