### PR TITLE
feat: add GetSysinfo for stat/sysinfo endpoint (unpoller#927)

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -49,6 +49,7 @@ func (u *Unifi) DiscoverEndpoints(site, outputPath string) error {
 		{"GET", fmt.Sprintf(APIClientTrafficPath, site, start, end, false)},
 		{"GET", fmt.Sprintf(APICountryTrafficPath, site, start, end)},
 		{"GET", fmt.Sprintf(APIAggregatedDashboard, site, 86400)},
+		{"GET", fmt.Sprintf(APISysinfoPath, site)},
 		{"GET", fmt.Sprintf(APIRogueAP, site)},
 		{"GET", fmt.Sprintf(APIAllUserPath, site)},
 		{"GET", fmt.Sprintf(APIEventPathIDS, site)},

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -676,3 +676,21 @@ func (m *MockUnifi) GetProtectLogs(_ *unifi.ProtectLogRequest) ([]*unifi.Protect
 
 	return results, nil
 }
+
+// GetSysinfo returns controller system info and health (UniFi OS).
+func (m *MockUnifi) GetSysinfo(_ []*unifi.Site) ([]*unifi.Sysinfo, error) {
+	results := make([]*unifi.Sysinfo, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var s unifi.Sysinfo
+
+		err := gofakeit.Struct(&s)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &s
+	}
+
+	return results, nil
+}

--- a/sysinfo.go
+++ b/sysinfo.go
@@ -1,0 +1,68 @@
+package unifi
+
+import "fmt"
+
+// Sysinfo holds controller system information and health from GET /proxy/network/api/s/{site}/stat/sysinfo.
+// UniFi OS only. See https://github.com/unpoller/unpoller/issues/927
+type Sysinfo struct {
+	SiteName     string   `json:"-"`
+	SourceName   string   `json:"-"`
+	Timezone     string   `json:"timezone"`
+	Autobackup   bool     `json:"autobackup"`
+	Build        string   `json:"build"`
+	Version      string   `json:"version"`
+	PreviousVer  string   `json:"previous_version"`
+	DataRetDays  int      `json:"data_retention_days"`
+	DataRet5min  int      `json:"data_retention_time_in_hours_for_5minutes_scale"`
+	DataRetHour  int      `json:"data_retention_time_in_hours_for_hourly_scale"`
+	DataRetDay   int      `json:"data_retention_time_in_hours_for_daily_scale"`
+	DataRetMonth int      `json:"data_retention_time_in_hours_for_monthly_scale"`
+	UpdateAvail  bool     `json:"update_available"`
+	UpdateDown   bool     `json:"update_downloaded"`
+	Hostname     string   `json:"hostname"`
+	Name         string   `json:"name"`
+	IPAddrs      []string `json:"ip_addrs"`
+	InformPort   int      `json:"inform_port"`
+	HTTPSPort    int      `json:"https_port"`
+	PortalPort   int      `json:"portal_http_port"`
+	Uptime       int64    `json:"uptime"`
+	AnonymousID  string   `json:"anonymous_controller_id"`
+	HasWebRTC    bool     `json:"has_webrtc_support"`
+	DeviceType   string   `json:"ubnt_device_type"`
+	UDMVersion   string   `json:"udm_version"`
+	Unsupported  int      `json:"unsupported_device_count"`
+	IsCloud      bool     `json:"is_cloud_console"`
+	ConsoleVer   string   `json:"console_display_version"`
+}
+
+// GetSysinfoSite returns controller system info for a single site.
+func (u *Unifi) GetSysinfoSite(site *Site) (*Sysinfo, error) {
+	path := fmt.Sprintf(APISysinfoPath, site.Name)
+
+	var s Sysinfo
+
+	if err := u.GetData(path, &s); err != nil {
+		return nil, err
+	}
+
+	s.SiteName = site.SiteName
+	s.SourceName = site.SourceName
+
+	return &s, nil
+}
+
+// GetSysinfo returns controller system info for all sites.
+func (u *Unifi) GetSysinfo(sites []*Site) ([]*Sysinfo, error) {
+	data := make([]*Sysinfo, 0, len(sites))
+
+	for _, site := range sites {
+		s, err := u.GetSysinfoSite(site)
+		if err != nil {
+			return nil, fmt.Errorf("GetSysinfo(%s): %w", site.Name, err)
+		}
+
+		data = append(data, s)
+	}
+
+	return data, nil
+}

--- a/types.go
+++ b/types.go
@@ -185,6 +185,8 @@ const (
 	APIWANLoadBalancingConfigPath string = "/proxy/network/v2/api/site/%s/wan/load-balancing/configuration"
 	// APIWANSLAsPath returns WAN SLA monitoring data (latency, packet loss, jitter).
 	APIWANSLAsPath string = "/proxy/network/v2/api/site/%s/wan-slas"
+	// APISysinfoPath returns controller system info and health (UniFi OS).
+	APISysinfoPath string = "/api/s/%s/stat/sysinfo"
 )
 
 // path returns the correct api path based on the new variable.
@@ -330,6 +332,8 @@ type UnifiClient interface { //nolint: revive
 	GetCountryTraffic(sites []*Site, epochMillisTimePeriod *EpochMillisTimePeriod) ([]*UsageByCountry, error)
 	// GetProtectLogs returns Protect system log events.
 	GetProtectLogs(req *ProtectLogRequest) ([]*ProtectLogEntry, error)
+	// GetSysinfo returns controller system info and health (UniFi OS).
+	GetSysinfo(sites []*Site) ([]*Sysinfo, error)
 }
 
 // Unifi is what you get in return for providing a password! Unifi represents


### PR DESCRIPTION
## Summary
Adds support for the `/api/s/{site}/stat/sysinfo` endpoint for controller system info and health metrics.

Resolves unpoller/unpoller#927

## Changes
- **sysinfo.go** (new): `Sysinfo` struct and `GetSysinfo` / `GetSysinfoSite` methods
- **types.go**: `APISysinfoPath` constant and `GetSysinfo` on `UnifiClient` interface
- **discover.go**: Include sysinfo endpoint in `DiscoverEndpoints`
- **mocks/mock_client.go**: Implement `GetSysinfo` in `MockUnifi`

## API Response (UniFi OS)
```json
{
    "hostname": "my-controller",
    "name": "My Controller",
    "version": "10.1.80",
    "uptime": 495322,
    "update_available": false,
    ...
}
```

Made with [Cursor](https://cursor.com)