### PR TITLE
feat(devices): add UDB device support

### DIFF
--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -285,6 +285,24 @@ func (m *MockUnifi) GetPDUs(_ *unifi.Site) ([]*unifi.PDU, error) {
 	return results, nil
 }
 
+// GetUDBs returns all UDB devices, an error, or nil if there are no UDBs.
+func (m *MockUnifi) GetUDBs(_ *unifi.Site) ([]*unifi.UDB, error) {
+	results := make([]*unifi.UDB, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.UDB
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
 // GetUSGs returns all 1Gb gateways, an error, or nil if there are no USGs.
 func (m *MockUnifi) GetUSGs(_ *unifi.Site) ([]*unifi.USG, error) {
 	results := make([]*unifi.USG, numItemsMocked)

--- a/mocks/mock_server.go
+++ b/mocks/mock_server.go
@@ -219,6 +219,10 @@ func (m *MockHTTPTestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			devices = append(devices, d)
 		}
 
+		for _, d := range device.UDBs {
+			devices = append(devices, d)
+		}
+
 		respondResultOrErr(w, devices, err, true)
 
 		return

--- a/types.go
+++ b/types.go
@@ -226,6 +226,7 @@ type Devices struct {
 	PDUs []*PDU `fakesize:"5"`
 	UBBs []*UBB `fakesize:"5"`
 	UCIs []*UCI `fakesize:"5"`
+	UDBs []*UDB `fakesize:"5"`
 }
 
 // Config is the data passed into our library. This configures things and allows
@@ -276,6 +277,8 @@ type UnifiClient interface { //nolint: revive
 	GetUCIs(site *Site) ([]*UCI, error)
 	// GetPDUs returns all PDU devices, an error, or nil if there are no PDUs.
 	GetPDUs(site *Site) ([]*PDU, error)
+	// GetUDBs returns all UDB devices, an error, or nil if there are no UDBs.
+	GetUDBs(site *Site) ([]*UDB, error)
 	// GetEvents returns a response full of UniFi Events for the last 1 hour from multiple sites.
 	GetEvents(sites []*Site, hours time.Duration) ([]*Event, error)
 	// GetSiteEvents retrieves the last 1 hour's worth of events from a single site.

--- a/udb.go
+++ b/udb.go
@@ -1,0 +1,195 @@
+package unifi
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UDB represents a UniFi Device Bridge (UDB) device.
+// The UDB product range includes: UDB-Switch, UDB-Pro, UDB-Pro-Sector.
+// UDB-Switch is a hybrid device combining switch ports (8 PoE ports:
+// 7x 2.5GbE + 1x 10GbE) with WiFi 7 wireless bridge capability
+// (5GHz + 6GHz radios).
+type UDB struct {
+	site                  *Site
+	AdoptableWhenUpgraded FlexBool         `json:"adoptable_when_upgraded,omitempty"`
+	Adopted               FlexBool         `fake:"{constFlexBool:true}"              json:"adopted"`
+	AdoptionCompleted     FlexBool         `json:"adoption_completed"`
+	Anomalies             FlexInt          `json:"anomalies"`
+	Architecture          string           `json:"architecture"`
+	BoardRev              FlexInt          `json:"board_rev"`
+	Bytes                 FlexInt          `json:"bytes"`
+	BytesD                FlexInt          `json:"bytes-d"`
+	BytesR                FlexInt          `json:"bytes-r"`
+	Cfgversion            string           `json:"cfgversion"`
+	ConfigNetwork         *ConfigNetwork   `json:"config_network"`
+	ConnectRequestIP      string           `json:"connect_request_ip"`
+	ConnectRequestPort    string           `json:"connect_request_port"`
+	ConnectedAt           FlexInt          `json:"connected_at"`
+	ConnectionNetworkName string           `json:"connection_network_name"`
+	CountryCode           FlexInt          `json:"country_code"`
+	DeviceID              string           `json:"device_id"`
+	DisplayableVersion    string           `json:"displayable_version"`
+	Dot1XPortctrlEnabled  FlexBool         `json:"dot1x_portctrl_enabled"`
+	DownlinkTable         []*DownlinkTable `json:"downlink_table"`
+	EthernetTable         []*EthernetTable `json:"ethernet_table"`
+	FanLevel              FlexInt          `json:"fan_level"`
+	FlowctrlEnabled       FlexBool         `json:"flowctrl_enabled"`
+	FwCaps                FlexInt          `json:"fw_caps"`
+	GatewayMac            string           `json:"gateway_mac"`
+	GeneralTemperature    FlexInt          `json:"general_temperature"`
+	GuestNumSta           FlexInt          `json:"guest-num_sta"`
+	GuestWlanNumSta       FlexInt          `json:"guest-wlan-num_sta"`
+	HasFan                FlexBool         `json:"has_fan"`
+	HasTemperature        FlexBool         `json:"has_temperature"`
+	HwCaps                FlexInt          `json:"hw_caps"`
+	ID                    string           `json:"_id"`
+	IP                    string           `json:"ip"`
+	InformIP              string           `json:"inform_ip"`
+	InformURL             string           `json:"inform_url"`
+	Internet              FlexBool         `json:"internet"`
+	IsAccessPoint         FlexBool         `json:"is_access_point"`
+	JumboframeEnabled     FlexBool         `json:"jumboframe_enabled"`
+	KernelVersion         string           `json:"kernel_version"`
+	KnownCfgversion       string           `json:"known_cfgversion"`
+	LCMTrackerEnabled     FlexBool         `json:"lcm_tracker_enabled"`
+	LastSeen              FlexInt          `json:"last_seen"`
+	LastUplink            struct {
+		UplinkMac string `json:"uplink_mac"`
+	} `json:"last_uplink"`
+	LedOverride         string   `json:"led_override"`
+	LicenseState        string   `json:"license_state"`
+	Locating            FlexBool `fake:"{constFlexBool:false}" json:"locating"`
+	Mac                 string   `json:"mac"`
+	Tags                []string `json:"tags"` // Device tags assigned to this device
+	ManufacturerID      FlexInt  `json:"manufacturer_id"`
+	MeshStaVapEnabled   FlexBool `json:"mesh_sta_vap_enabled"`
+	Model               string   `json:"model"`
+	ModelInEOL          FlexBool `json:"model_in_eol"`
+	ModelInLTS          FlexBool `json:"model_in_lts"`
+	ModelIncompatible   FlexBool `json:"model_incompatible"`
+	Name                string   `fake:"{animal}"              json:"name"`
+	NextInterval        FlexInt  `json:"next_interval"`
+	NumSta              FlexInt  `json:"num_sta"`
+	OutdoorModeOverride string   `json:"outdoor_mode_override"`
+	Overheating         FlexBool `json:"overheating"`
+	PortOverrides       []struct {
+		Name       string  `json:"name,omitempty"`
+		PoeMode    string  `json:"poe_mode,omitempty"`
+		PortIdx    FlexInt `json:"port_idx"`
+		PortconfID string  `json:"portconf_id"`
+	} `json:"port_overrides"`
+	PortTable               []Port          `json:"port_table"`
+	PowerSource             string          `json:"power_source"`
+	PowerSourceCtrlEnabled  FlexBool        `json:"power_source_ctrl_enabled"`
+	PowerSourceVoltage      string          `json:"power_source_voltage"`
+	PreviousNonBusyState    FlexInt         `json:"prev_non_busy_state"`
+	ProvisionedAt           FlexInt         `json:"provisioned_at"`
+	RadioTable              RadioTable      `json:"radio_table"`
+	RadioTableStats         RadioTableStats `json:"radio_table_stats"`
+	RequiredVersion         string          `json:"required_version"`
+	Rollupgrade             FlexBool        `json:"rollupgrade,omitempty"`
+	RxBytes                 FlexInt         `json:"rx_bytes"`
+	RxBytesD                FlexInt         `json:"rx_bytes-d"`
+	Satisfaction            FlexInt         `json:"satisfaction"`
+	Serial                  string          `json:"serial"`
+	SetupID                 string          `json:"setup_id"`
+	SiteID                  string          `json:"site_id"`
+	SiteName                string          `json:"-"`
+	SourceName              string          `json:"-"`
+	StartConnectedMillis    FlexInt         `json:"start_connected_millis"`
+	StartDisconnectedMillis FlexInt         `json:"start_disconnected_millis"`
+	StartupTimestamp        FlexInt         `json:"startup_timestamp"`
+	Stat                    UDBStat         `json:"stat"`
+	State                   FlexInt         `json:"state"`
+	StpPriority             FlexInt         `json:"stp_priority"`
+	StpVersion              string          `json:"stp_version"`
+	SwitchCaps              *SwitchCaps     `json:"switch_caps"`
+	SysErrorCaps            FlexInt         `json:"sys_error_caps"`
+	SysStats                SysStats        `json:"sys_stats"`
+	SystemStats             SystemStats     `json:"system-stats"`
+	TotalMaxPower           FlexInt         `json:"total_max_power"`
+	TotalRxBytes            FlexInt         `json:"total_rx_bytes"`
+	TotalTxBytes            FlexInt         `json:"total_tx_bytes"`
+	TwoPhaseAdopt           FlexBool        `json:"two_phase_adopt"`
+	TxBytes                 FlexInt         `json:"tx_bytes"`
+	TxBytesD                FlexInt         `json:"tx_bytes-d"`
+	Type                    string          `fake:"{randomstring:[udb]}"      json:"type"`
+	Unsupported             FlexBool        `json:"unsupported"`
+	UnsupportedReason       FlexInt         `json:"unsupported_reason"`
+	Upgradable              FlexBool        `json:"upgradable,omitempty"`
+	Upgradeable             FlexBool        `json:"upgradeable"`
+	Uplink                  Uplink          `json:"uplink"`
+	UplinkDepth             FlexInt         `json:"uplink_depth"`
+	Uptime                  FlexInt         `json:"uptime"`
+	UserNumSta              FlexInt         `json:"user-num_sta"`
+	UserWlanNumSta          FlexInt         `json:"user-wlan-num_sta"`
+	VapTable                VapTable        `json:"vap_table"`
+	Version                 string          `json:"version"`
+	VwireEnabled            FlexBool        `json:"vwireEnabled"`
+	VwireTable              []interface{}   `json:"vwire_table"`
+	VwireVapTable           []interface{}   `json:"vwire_vap_table"`
+	WifiCaps                FlexInt         `json:"wifi_caps"`
+	WlangroupIDNa           string          `json:"wlangroup_id_na"`
+	WlangroupIDNg           string          `json:"wlangroup_id_ng"`
+}
+
+// UDBStat holds the "stat" data for a UDB (UniFi Device Bridge) device.
+// This is split out because of a JSON data format change from 5.10 to 5.11.
+// Contains device bridge stats (Db) and switch stats (Sw).
+type UDBStat struct {
+	*Db
+	*Sw
+}
+
+// Db holds UDB-specific statistics (device bridge metrics).
+// Named "db" to match the JSON key in the UniFi API response.
+type Db struct {
+	SiteID      string    `fake:"{uuid}"        json:"site_id"`
+	O           string    `json:"o"`
+	Oid         string    `json:"oid"`
+	Db          string    `json:"db"`
+	Time        FlexInt   `json:"time"`
+	Datetime    time.Time `fake:"{recent_time}" json:"datetime"`
+	Bytes       FlexInt   `json:"bytes"`
+	Duration    FlexInt   `json:"duration"`
+	RxBytes     FlexInt   `json:"rx_bytes"`
+	RxPackets   FlexInt   `json:"rx_packets"`
+	RxErrors    FlexInt   `json:"rx_errors"`
+	RxDropped   FlexInt   `json:"rx_dropped"`
+	RxCrypts    FlexInt   `json:"rx_crypts"`
+	RxFrags     FlexInt   `json:"rx_frags"`
+	RxMulticast FlexInt   `json:"rx_multicast"`
+	RxBroadcast FlexInt   `json:"rx_broadcast"`
+	TxBytes     FlexInt   `json:"tx_bytes"`
+	TxPackets   FlexInt   `json:"tx_packets"`
+	TxErrors    FlexInt   `json:"tx_errors"`
+	TxDropped   FlexInt   `json:"tx_dropped"`
+	TxRetries   FlexInt   `json:"tx_retries"`
+	TxMulticast FlexInt   `json:"tx_multicast"`
+	TxBroadcast FlexInt   `json:"tx_broadcast"`
+}
+
+// UnmarshalJSON unmarshalls 5.10 or 5.11 formatted UDB Stat data.
+// Supports both nested (5.11+) and flat (5.10) JSON formats.
+func (v *UDBStat) UnmarshalJSON(data []byte) error {
+	var nested struct {
+		Db `json:"db"`
+		Sw `json:"sw"`
+	}
+
+	v.Db = &nested.Db
+	v.Sw = &nested.Sw
+
+	// Try flat format first (controller version 5.10)
+	err := json.Unmarshal(data, v.Sw)
+	if err != nil {
+		// Try nested format (controller version 5.11+)
+		return json.Unmarshal(data, &nested)
+	}
+
+	// Also try to unmarshal db stats from flat format
+	_ = json.Unmarshal(data, v.Db)
+
+	return nil
+}

--- a/udb_test.go
+++ b/udb_test.go
@@ -1,0 +1,16 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestUDB(test *testing.T) {
+	udb := unifi.UDB{}
+	err := gofakeit.Struct(&udb)
+	require.NoError(test, err)
+	require.NotEmpty(test, udb.Name)
+}

--- a/unifi.go
+++ b/unifi.go
@@ -172,6 +172,7 @@ func (u *Unifi) Login() error {
 
 	if resp.StatusCode == http.StatusTooManyRequests {
 		after := parseRetryAfter(resp.Header.Get("Retry-After"))
+
 		return &RateLimitError{RetryAfter: after}
 	}
 
@@ -190,26 +191,33 @@ func parseRetryAfter(s string) time.Duration {
 	if s == "" {
 		return 60 * time.Second
 	}
+
 	if sec, err := strconv.Atoi(s); err == nil && sec > 0 {
 		d := time.Duration(sec) * time.Second
 		if d > 5*time.Minute {
 			return 5 * time.Minute
 		}
+
 		if d < time.Second {
 			return time.Second
 		}
+
 		return d
 	}
+
 	if t, err := http.ParseTime(s); err == nil {
 		d := time.Until(t)
 		if d < time.Second {
 			return time.Second
 		}
+
 		if d > 5*time.Minute {
 			return 5 * time.Minute
 		}
+
 		return d
 	}
+
 	return 60 * time.Second
 }
 
@@ -491,6 +499,7 @@ func (u *Unifi) do(req *http.Request) ([]byte, error) {
 
 	if resp.StatusCode == http.StatusTooManyRequests {
 		after := parseRetryAfter(resp.Header.Get("Retry-After"))
+
 		return body, &RateLimitError{RetryAfter: after}
 	}
 

--- a/wan.go
+++ b/wan.go
@@ -188,6 +188,7 @@ func (u *Unifi) GetWANEnrichedConfiguration(sites []*Site) ([]*WANEnrichedConfig
 		if strings.Contains(path, "%s") {
 			return nil, fmt.Errorf("WAN enriched-config path still contains %%s (site name may be empty): %q", path)
 		}
+
 		u.DebugLog("Fetching WAN enriched configuration for site %s", site.Name)
 
 		body, err := u.GetJSON(path)
@@ -199,6 +200,7 @@ func (u *Unifi) GetWANEnrichedConfiguration(sites []*Site) ([]*WANEnrichedConfig
 		if err := json.Unmarshal(body, &raw); err != nil {
 			return nil, err
 		}
+
 		for _, wan := range raw {
 			if wan != nil {
 				data = append(data, wan)
@@ -216,6 +218,7 @@ func (u *Unifi) GetWANLoadBalancingStatus(sites []*Site) (*WANLoadBalancingStatu
 	}
 
 	site := sites[0]
+
 	path := fmt.Sprintf(APIWANLoadBalancingStatusPath, site.Name)
 	if strings.Contains(path, "%s") {
 		return &WANLoadBalancingStatus{}, fmt.Errorf("WAN load-balancing path still contains %%s (site name empty): %q", path)
@@ -232,6 +235,7 @@ func (u *Unifi) GetWANLoadBalancingStatus(sites []*Site) (*WANLoadBalancingStatu
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, err
 	}
+
 	return &response, nil
 }
 
@@ -242,6 +246,7 @@ func (u *Unifi) GetWANISPStatus(sites []*Site, wanNetworkgroup string) (*WANISPS
 	}
 
 	site := sites[0]
+
 	path := fmt.Sprintf(APIWANISPStatusPath, site.Name, wanNetworkgroup)
 	if strings.Contains(path, "%s") {
 		return &WANISPStatusDetailed{}, fmt.Errorf("WAN ISP status path still contains %%s: %q", path)
@@ -258,6 +263,7 @@ func (u *Unifi) GetWANISPStatus(sites []*Site, wanNetworkgroup string) (*WANISPS
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, err
 	}
+
 	return &response, nil
 }
 
@@ -282,8 +288,10 @@ func (u *Unifi) GetWANSLAs(sites []*Site) ([]*WANSLA, error) {
 		if err := json.Unmarshal(body, &response); err != nil {
 			return nil, err
 		}
+
 		if len(response) == 0 {
 			u.DebugLog("No WAN SLAs found for site %s", site.Name)
+
 			continue
 		}
 
@@ -291,8 +299,10 @@ func (u *Unifi) GetWANSLAs(sites []*Site) ([]*WANSLA, error) {
 			var sla WANSLA
 			if err := json.Unmarshal(raw, &sla); err != nil {
 				u.DebugLog("Error parsing WAN SLA: %v", err)
+
 				continue
 			}
+
 			data = append(data, &sla)
 		}
 	}


### PR DESCRIPTION
## Summary
Adds UDB (UniFi Device Bridge) device type support to the unifi library.

Resolves unpoller/unpoller#947

## Changes
- **udb.go**: New UDB struct with switch and wireless bridge fields
- **devices.go**: Add UDBs to Devices struct
- **types.go**: Add UDB type constant
- **mocks/mock_client.go**: Add GetUDBs mock implementation
- **mocks/mock_server.go**: Include UDBs in device API response
- **udb_test.go**: Unit test for UDB struct

## Device Type
The UDB is a hybrid device combining switch functionality with wireless bridge capabilities. It includes:
- Standard device fields (name, mac, model, serial, uptime, temperatures)
- Switch port statistics
- Wireless bridge statistics (satisfaction, sta counts)
- Uplink statistics

Made with [Claude Code](https://claude.ai/claude-code)