### PR TITLE
chore: apply linter tag-alignment and whitespace fixes

### DIFF
--- a/firewall_policies.go
+++ b/firewall_policies.go
@@ -53,7 +53,7 @@ type FirewallPolicySchedule struct {
 // FirewallPolicy represents a firewall policy rule from the UniFi controller.
 type FirewallPolicy struct {
 	ID                  string                 `json:"_id"`
-	Action              string                 `json:"action"`               // ALLOW, BLOCK, REJECT
+	Action              string                 `json:"action"`                // ALLOW, BLOCK, REJECT
 	ConnectionStateType string                 `json:"connection_state_type"` // ALL, CUSTOM
 	ConnectionStates    []string               `json:"connection_states"`
 	CreateAllowRespond  FlexBool               `json:"create_allow_respond"`

--- a/pdu_test.go
+++ b/pdu_test.go
@@ -21,11 +21,11 @@ func TestPDUUnmarshalJSON(t *testing.T) {
 	err := json.Unmarshal(pduSample, p)
 	a.Nil(err, "must be no error unmarshaling test strings")
 	a.Equal(powerBudgetVal, p.OutletACPowerBudget.Val, "data was not properly unmarshaled")
-	
+
 	// Verify outlet table is parsed correctly
 	a.NotNil(p.OutletTable, "outlet_table should not be nil")
 	a.Greater(len(p.OutletTable), 0, "outlet_table should have entries")
-	
+
 	// Verify outlet_current is parsed correctly for outlets that have it
 	for _, outlet := range p.OutletTable {
 		if outlet.OutletCaps.Val >= 3 {
@@ -33,12 +33,12 @@ func TestPDUUnmarshalJSON(t *testing.T) {
 			a.NotNil(&outlet.OutletCurrent, "outlet_current should be accessible")
 		}
 	}
-	
+
 	// Verify specific outlet with known current value (Outlet 5 from example has 0.086)
 	for _, outlet := range p.OutletTable {
 		if outlet.Index.Val == 5 {
 			expectedCurrent := 0.086
-			a.InDelta(expectedCurrent, outlet.OutletCurrent.Val, 0.001, 
+			a.InDelta(expectedCurrent, outlet.OutletCurrent.Val, 0.001,
 				"outlet 5 should have current value of approximately 0.086")
 		}
 	}

--- a/topology.go
+++ b/topology.go
@@ -33,21 +33,21 @@ func (u *Unifi) GetTopology(sites []*Site) ([]*Topology, error) {
 
 // TopologyVertex represents a node in the network topology (device or client).
 type TopologyVertex struct {
-	AllowedInVisualProgramming bool             `json:"allowedInVisualProgramming"`
-	Default                    bool             `json:"default"`
-	Mac                        string           `json:"mac"`
-	Model                      string           `json:"model"`
-	Name                       string           `json:"name"`
-	State                      FlexInt          `json:"state"`
-	Type                       string           `json:"type"` // DEVICE or CLIENT
-	UnifiDevice                bool             `json:"unifiDevice"`
-	WifiRadios                 []TopologyRadio  `json:"wifiRadios"`
+	AllowedInVisualProgramming bool            `json:"allowedInVisualProgramming"`
+	Default                    bool            `json:"default"`
+	Mac                        string          `json:"mac"`
+	Model                      string          `json:"model"`
+	Name                       string          `json:"name"`
+	State                      FlexInt         `json:"state"`
+	Type                       string          `json:"type"` // DEVICE or CLIENT
+	UnifiDevice                bool            `json:"unifiDevice"`
+	WifiRadios                 []TopologyRadio `json:"wifiRadios"`
 }
 
 // TopologyRadio represents a WiFi radio on a device vertex.
 type TopologyRadio struct {
 	Channel   FlexInt `json:"channel"`
-	Protocol  string  `json:"protocol"` // ax, ac, n, g
+	Protocol  string  `json:"protocol"`  // ax, ac, n, g
 	RadioBand string  `json:"radioBand"` // ng (2.4GHz), na (5GHz), 6e (6GHz)
 }
 
@@ -56,7 +56,7 @@ type TopologyEdge struct {
 	Channel            FlexInt `json:"channel"`
 	DownlinkMac        string  `json:"downlinkMac"`
 	DownlinkPortNumber FlexInt `json:"downlinkPortNumber"`
-	Duplex             string  `json:"duplex"`    // FULL_DUPLEX, HALF_DUPLEX
+	Duplex             string  `json:"duplex"` // FULL_DUPLEX, HALF_DUPLEX
 	Essid              string  `json:"essid"`
 	ExperienceScore    FlexInt `json:"experienceScore"`
 	NetworkID          string  `json:"networkId"`


### PR DESCRIPTION
## Summary

- Applies `golangci-lint` auto-fixes that were flagged but not yet committed:
  - `firewall_policies.go`: `tagalign` — align struct field tag spacing
  - `topology.go`: `tagalign` — align struct field tag spacing
  - `pdu_test.go`: `wsl_v5` — remove trailing whitespace on blank lines

No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)