### PR TITLE
feat: Integration/v1 coverage — paginated list helper, hardened sentinels, full getter set

### DIFF
--- a/POTENTIAL_FEATURES.md
+++ b/POTENTIAL_FEATURES.md
@@ -1,163 +1,387 @@
 # Potential Features to Add to unpoller/unifi
 
-Based on analysis of API response examples, here are features that could be added:
+Based on analysis of API response examples, here are features that could be added.
 
-## 1. System Information (`/api/s/{site}/stat/sysinfo`)
-
-**Status**: Not implemented
-
-**Data Available**:
-- Controller version, build, previous version
-- Timezone, hostname, IP addresses
-- Ports (inform, https, portal_http)
-- Uptime
-- Data retention settings
-- Update availability
-- Device type (UDRULT, etc.)
-- Debug settings
-- SSO app ID
-- Anonymous controller ID
-- WebRTC support
-- Unsupported device count/list
-
-**Use Case**: Monitoring controller health, version tracking, uptime monitoring
-
-**Implementation**: Add `GetSysInfo(site *Site) (*SysInfo, error)` method
+Status key: **Done** = shipped, **Partial** = some coverage, **Open** = not started.
 
 ---
 
-## 2. WAN Status (`/api/s/{site}/stat/status`)
+## Part A — Legacy / v2 API gaps
 
-**Status**: Not implemented
+### A1. System Information (`/api/s/{site}/stat/sysinfo`)
 
-**Data Available**:
-- WAN interface names
-- WAN states (ACTIVE, BACKUP)
-- WAN network groups (WAN, WAN2, etc.)
-
-**Use Case**: Monitor WAN failover status, active/backup WAN interfaces
-
-**Implementation**: Add `GetWANStatus(site *Site) (*WANStatus, error)` method
+**Status**: Done (`sysinfo.go`)
 
 ---
 
-## 3. Firewall Policies (`/api/s/{site}/rest/firewall-policies`)
+### A2. WAN Status (`/api/s/{site}/stat/status`)
 
-**Status**: Not implemented
+**Status**: Open
 
-**Data Available**:
-- Firewall rules with zone-based configuration
-- Actions (ALLOW, BLOCK)
-- Source/destination zones
-- Protocols (all, udp, icmpv6, etc.)
-- Port matching
-- IP version (BOTH, IPV4, IPV6)
-- Connection states
-- ICMP types
-- Logging settings
-- Schedule (ALWAYS mode shown)
-- Predefined vs custom rules
-- Index/priority
+**Data**: WAN interface names, states (ACTIVE/BACKUP), network groups (WAN, WAN2).
 
-**Use Case**: Firewall rule auditing, security monitoring, rule analysis
+**Use case**: WAN failover monitoring.
 
-**Implementation**: Add `GetFirewallPolicies(site *Site) ([]*FirewallPolicy, error)` method
-
-**Note**: This is a significant feature with complex zone-based firewall data
+**Implementation**: `GetWANStatus(site *Site) (*WANStatus, error)`
 
 ---
 
-## 4. UPS Devices List (`/api/s/{site}/stat/ups-devices`)
+### A3. Firewall Policies (`/proxy/network/v2/api/site/{site}/firewall-policies`)
 
-**Status**: Partially implemented (PDU/UPS devices come from `/stat/device`, but this endpoint provides a different format)
-
-**Data Available**:
-- Device selector format with image, label, metadata
-- Device MAC addresses
-- Site IDs
-- Device identification for UI selection
-
-**Use Case**: Quick UPS device lookup, device selection lists
-
-**Implementation**: Add `GetUPSDeviceList(site *Site) ([]*UPSDeviceSelector, error)` method
-
-**Note**: Different from full device data - this is a lightweight selector format
+**Status**: Done (`firewall_policies.go`)
 
 ---
 
-## 5. Enhanced Network Configuration
+### A4. UPS Device List (`/api/s/{site}/stat/ups-devices`)
 
-**Status**: Partially implemented (basic Network struct exists, but missing many fields)
+**Status**: Partial (PDU/UPS come from `/stat/device`; this endpoint is a lightweight selector format)
 
-**Missing Fields from `/api/s/{site}/rest/networkconf`**:
-- WAN-specific: `wan_type`, `wan_dhcp_options`, `wan_load_balance_type`, `wan_failover_priority`, `wan_provider_capabilities`, `wan_ip_aliases`, `wan_smartq_enabled`, `wan_dns_preference`, `wan_vlan_enabled`, `wan_ipv6_dns_preference`, `wan_ipv6_dns1/2`, `ipv6_wan_delegation_type`, `wan_dhcpv6_pd_size_auto`
-- IPv6: `ipv6_enabled`, `ipv6_setting_preference`, `ipv6_interface_type`, `ipv6_pd_start/stop`, `ipv6_pd_auto_prefixid_enabled`, `ipv6_ra_enabled`, `ipv6_ra_preferred_lifetime`, `ipv6_ra_priority`, `ipv6_client_address_assignment`, `dhcpdv6_*` fields
-- VPN: `vpn_type`, `sdwan_remote_site_id`, `remote_vpn_subnets`, `ifname` (for site-vpn)
-- Advanced: `firewall_zone_id`, `routing_table_id`, `external_id`, `igmp_proxy_*`, `mac_override_enabled`, `setting_preference`, `report_wan_event`, `attr_no_delete`, `attr_hidden_id`, `attr_no_edit`
-- DHCP: `dhcpdv6_*` fields, `dhcpd_wpad_url`, `dhcpd_tftp_server`, `dhcpd_boot_enabled`, `dhcpd_ntp_enabled`, `dhcpd_wins_enabled`
-- Other: `lte_lan_enabled`, `upnp_lan_enabled`, `mdns_enabled`, `auto_scale_enabled`, `dhcpguard_enabled`, `dhcpd_conflict_checking`, `dhcpd_time_offset_enabled`, `dhcpd_gateway_enabled`, `dhcp_relay_enabled`, `nat_outbound_ip_addresses`, `single_network_lan`, `gateway_type`, `domain_name`
+**Data**: Device MAC, image URL, label, site ID — for UI selection lists, not full stats.
 
-**Use Case**: Full network configuration monitoring, WAN failover configuration, IPv6 support, VPN monitoring
-
-**Implementation**: Extend `Network` struct with additional fields, or create `NetworkExtended` struct
+**Implementation**: `GetUPSDeviceList(site *Site) ([]*UPSDeviceSelector, error)`
 
 ---
 
-## 6. Port Forwarding (`/api/s/{site}/rest/portforward`)
+### A5. Enhanced Network Configuration (`/api/s/{site}/rest/networkconf`)
 
-**Status**: Not implemented (endpoint exists but returns empty array in example)
+**Status**: Partial (basic `Network` struct exists; many fields missing)
 
-**Data Available**: (when configured)
-- Port forward rules
-- Source/destination ports
-- Protocols
-- Enabled status
+**Missing fields**: WAN failover (`wan_load_balance_type`, `wan_failover_priority`), IPv6 (`ipv6_enabled`, `dhcpdv6_*`), VPN (`vpn_type`, `sdwan_remote_site_id`), DHCP advanced (`dhcpd_ntp_enabled`, `dhcpd_wins_enabled`), misc (`firewall_zone_id`, `mdns_enabled`) — `domain_name` is already present as `DomainName`.
 
-**Use Case**: Port forward rule auditing
-
-**Implementation**: Add `GetPortForwards(site *Site) ([]*PortForward, error)` method
+**Implementation**: Extend `Network` struct in-place (additive fields, no breakage).
 
 ---
 
-## 7. SSL Certificate Info (`/api/s/{site}/stat/active`)
+### A6. Port Forwarding (`/api/s/{site}/rest/portforward`)
 
-**Status**: Not implemented
+**Status**: Open
 
-**Data Available**:
-- Certificate details (root, intermediate)
-- Certificate status (active, valid)
-- Certificate type (generated)
-- Valid from/to dates
-- Issuer/subject information
-- Fingerprint, serial number
+**Data**: Port forward rules — source/destination ports, protocols, enabled flag.
 
-**Use Case**: SSL certificate monitoring, expiration tracking
-
-**Implementation**: Add `GetSSLCertificate(site *Site) (*SSLCertificate, error)` method
+**Implementation**: `GetPortForwards(site *Site) ([]*PortForward, error)`
 
 ---
 
-## Priority Recommendations
+### A7. SSL Certificate Info (`/api/s/{site}/stat/active`)
 
-### High Priority
-1. **SysInfo** - Useful for monitoring and health checks
-2. **WAN Status** - Important for failover monitoring
-3. **Enhanced Network Config** - Many missing fields that users might need
+**Status**: Open
 
-### Medium Priority
-4. **Firewall Policies** - Complex but valuable for security auditing
-5. **SSL Certificate** - Useful for certificate management
+**Data**: Certificate chain, status, valid-from/to dates, issuer, fingerprint.
 
-### Low Priority
-6. **UPS Device List** - Different format, may not be needed if device endpoint covers it
-7. **Port Forwarding** - Less commonly used, endpoint was empty in example
+**Use case**: Certificate expiration monitoring.
+
+**Implementation**: `GetSSLCertificate(site *Site) (*SSLCertificate, error)`
 
 ---
 
-## Implementation Notes
+## Part B — Integration/v1 API coverage
 
-- All endpoints follow the standard `/api/s/{site}/...` pattern
-- Most return `{"meta": {"rc": "ok"}, "data": [...]}` format
-- Some endpoints (like `status`) return different formats
-- Need to handle UDM Pro `/proxy/network` prefix
-- Consider backward compatibility when extending existing structs
+The controller exposes a formally supported REST API at `/proxy/network/integration/v1/` (available since Network 9.3.43, spec at `/proxy/network/api-docs/integration.json`). It requires `X-API-Key` auth and uses **UUID site IDs** (not the legacy short name `"default"`). The library currently reads from **none** of these endpoints.
+
+This API has 44 paths (source: `/proxy/network/api-docs/integration.json` on 10.3.58). Of those, 36 are GET operations; the remainder are write-only (POST/PUT/DELETE/PATCH). The 36 GETs collapse into 17 features (B0–B16) because list and single-item endpoints for the same resource are grouped together. Write operations are excluded — the library is read-only by design.
+
+### B0. Infrastructure: site ID resolution (prerequisite for all B-phase work)
+
+**Status**: Open
+
+**Problem**: Integration/v1 per-site endpoints use a UUID `siteId` from `GET /v1/sites`, not the legacy `Site.Name` short name. These are different identifiers.
+
+**Solution**: New type and getter:
+
+```go
+// IntegrationSite holds identity fields from GET /v1/sites.
+// InternalReference matches legacy Site.Name for cross-lookup.
+type IntegrationSite struct {
+    ID                string `json:"id"`                // UUID — pass to all integration/v1 calls
+    InternalReference string `json:"internalReference"` // equals legacy Site.Name ("default")
+    Name              string `json:"name"`
+}
+
+func (u *Unifi) GetIntegrationSites() ([]*IntegrationSite, error)
+```
+
+Callers who already have `[]*Site` from `GetSites()` join on `site.Name == integrationSite.InternalReference` to get the UUID. All per-site integration/v1 getters take `*IntegrationSite`.
+
+**Files**: new `integration_sites.go`; path constant `APIIntegrationSitesPath` in `types.go`; add to `UnifiClient` interface; add to `mocks/`.
+
+---
+
+### B1. Device statistics (`GET /v1/sites/{siteId}/devices/{deviceId}/statistics/latest`)
+
+**Status**: Open
+
+**Data**: `uptimeSec`, `cpuUtilizationPct`, `memoryUtilizationPct`, `loadAverage{1,5,15}Min`, `lastHeartbeatAt`, `nextHeartbeatAt`, per-radio `txRetriesPct`/`frequencyGHz`, per-uplink `txRateBps`/`rxRateBps`.
+
+**Use case**: Per-device CPU/memory/uptime metrics — currently only available embedded in the large legacy device payload. This is a clean dedicated stats endpoint.
+
+**Implementation**:
+```go
+GetIntegrationDeviceStats(site *IntegrationSite, deviceID string) (*IntegrationDeviceStats, error)
+// Convenience bulk getter: enumerates device IDs via GET /v1/sites/{siteId}/devices first.
+GetAllIntegrationDeviceStats(site *IntegrationSite) ([]*IntegrationDeviceStats, error)
+```
+
+**Files**: `integration_devices.go`
+
+---
+
+### B2. WiFi broadcasts (`GET /v1/sites/{siteId}/wifi/broadcasts`)
+
+**Status**: Open
+
+**Data**: `id`, `name`, `enabled`, `network` (VLAN reference), `securityConfiguration` (type: WPA2/WPA3/open, PSK, RADIUS profile ref), `broadcastingDeviceFilter`. Single-broadcast getter at `/{wifiBroadcastId}`.
+
+**Use case**: SSID inventory — the library has no WiFi broadcast / SSID data today.
+
+**Implementation**: `GetWifiBroadcasts(site *IntegrationSite) ([]*WifiBroadcast, error)`
+
+**Files**: `wifi_broadcasts.go`
+
+---
+
+### B3. Firewall zones (`GET /v1/sites/{siteId}/firewall/zones`)
+
+**Status**: Open
+
+**Data**: `id`, `name`, `networkIds` (list of network UUIDs in the zone), `metadata` (origin: system/user).
+
+**Use case**: The existing `GetFirewallPolicies()` returns policies that reference zone IDs — without zone data, those IDs are opaque. This completes the firewall picture.
+
+**Implementation**: `GetFirewallZones(site *IntegrationSite) ([]*FirewallZone, error)`
+
+**Files**: `firewall_zones.go`
+
+---
+
+### B4. ACL rules (`GET /v1/sites/{siteId}/acl-rules`)
+
+**Status**: Open
+
+**Data**: `id`, `enabled`, `name`, `description`, `action` (ALLOW/BLOCK), `enforcingDeviceFilter`, `index`, `sourceFilter`. Single-rule getter at `/{aclRuleId}`. Ordering at `/ordering`.
+
+**Use case**: Network access-control visibility; currently no ACL data in the library.
+
+**Implementation**: `GetACLRules(site *IntegrationSite) ([]*ACLRule, error)`
+
+**Files**: `acl_rules.go`
+
+---
+
+### B5. Networks (`GET /v1/sites/{siteId}/networks`)
+
+**Status**: Open
+
+**Data**: `id`, `name`, `enabled`, `vlanId`, `management` (gateway/switch-managed/unmanaged), `dhcpGuarding`. More structured than the legacy `/rest/networkconf` response. Single-network getter at `/{networkId}`; references at `/{networkId}/references`.
+
+**Use case**: Clean network inventory; complements the legacy `GetNetworks()` which remains for backward compat.
+
+**Implementation**: `GetIntegrationNetworks(site *IntegrationSite) ([]*IntegrationNetwork, error)`
+
+**Files**: `integration_networks.go`
+
+---
+
+### B6. WAN interfaces (`GET /v1/sites/{siteId}/wans`)
+
+**Status**: Open
+
+**Data**: `id`, `name`. Lightweight list of WAN interface identifiers.
+
+**Use case**: Enumerate WAN interfaces to drive the existing v2 WAN enriched/SLA calls by interface ID.
+
+**Implementation**: `GetIntegrationWANs(site *IntegrationSite) ([]*IntegrationWAN, error)`
+
+**Files**: extend `wan.go` or new `integration_wans.go`
+
+---
+
+### B7. VPN servers + site-to-site tunnels
+
+**Status**: Open
+
+**Data**:
+- `GET /v1/sites/{siteId}/vpn/servers` → `id`, `name`, `enabled`, `type` (L2TP/OpenVPN/WireGuard/UID)
+- `GET /v1/sites/{siteId}/vpn/site-to-site-tunnels` → `id`, `name`, `type` (IPSec/OpenVPN/WireGuard), `metadata`
+
+**Use case**: VPN infrastructure visibility; complements the existing `GetMagicSiteToSiteVPN()` (v2 API).
+
+**Implementation**:
+```go
+GetVPNServers(site *IntegrationSite) ([]*VPNServer, error)
+GetSiteToSiteTunnels(site *IntegrationSite) ([]*SiteToSiteTunnel, error)
+```
+
+**Files**: `vpn_servers.go` (or extend `vpn.go`)
+
+---
+
+### B8. Switching topology (LAGs, MC-LAG domains, switch stacks)
+
+**Status**: Open
+
+**Data**:
+- `GET /v1/sites/{siteId}/switching/lags` → `id`, `type` (local/global), `members` (device ID + port indexes), `metadata`
+- `GET /v1/sites/{siteId}/switching/mc-lag-domains` → `id`, `name`, `peers` (role + device ID + link ports), `lags`, `metadata`
+- `GET /v1/sites/{siteId}/switching/switch-stacks` → `id`, `name`, `members` (device IDs), `lags`, `metadata`
+
+**Use case**: Switching topology not available via any current endpoint. Required for understanding LAG/MLAG/stack relationships between switches.
+
+**Implementation**:
+```go
+GetLAGs(site *IntegrationSite) ([]*LAG, error)
+GetMCLAGDomains(site *IntegrationSite) ([]*MCLAGDomain, error)
+GetSwitchStacks(site *IntegrationSite) ([]*SwitchStack, error)
+```
+
+**Files**: `switching.go`
+
+---
+
+### B9. DNS policies (`GET /v1/sites/{siteId}/dns/policies`)
+
+**Status**: Open
+
+**Data**: `id`, `enabled`, `type` (forward-domain/block/allow/etc.), `domain`. Single-policy getter at `/{dnsPolicyId}`.
+
+**Use case**: DNS filtering / split-horizon visibility.
+
+**Implementation**: `GetDNSPolicies(site *IntegrationSite) ([]*DNSPolicy, error)`
+
+**Files**: `dns_policies.go`
+
+---
+
+### B10. RADIUS profiles (`GET /v1/sites/{siteId}/radius/profiles`)
+
+**Status**: Open
+
+**Data**: `id`, `name`, `metadata`. Reference data used by WiFi enterprise security configs.
+
+**Implementation**: `GetRADIUSProfiles(site *IntegrationSite) ([]*RADIUSProfile, error)`
+
+**Files**: `radius_profiles.go`
+
+---
+
+### B11. Traffic matching lists (`GET /v1/sites/{siteId}/traffic-matching-lists`)
+
+**Status**: Open
+
+**Data**: `id`, `name`, `type` (IPv4/IPv6/port). Used as references in firewall policy traffic filters.
+
+**Implementation**: `GetTrafficMatchingLists(site *IntegrationSite) ([]*TrafficMatchingList, error)`
+
+**Files**: `traffic_matching_lists.go`
+
+---
+
+### B12. Hotspot vouchers (`GET /v1/sites/{siteId}/hotspot/vouchers`)
+
+**Status**: Open
+
+**Data**: `id`, `code`, `name`, `authorizedGuestLimit`, `authorizedGuestCount`, `activatedAt`, `expiresAt`, `timeLimitMinutes`, `dataUsageLimitMBytes`, rate limits.
+
+**Use case**: Guest portal monitoring — voucher usage, expiry, capacity.
+
+**Implementation**: `GetHotspotVouchers(site *IntegrationSite) ([]*HotspotVoucher, error)`
+
+**Files**: `hotspot_vouchers.go`
+
+---
+
+### B13. DPI application catalogue (`GET /v1/dpi/applications`, `GET /v1/dpi/categories`)
+
+**Status**: Open
+
+**Data**: `id`, `name` for each application and category. Reference tables that decode the integer IDs in existing DPI stat responses.
+
+**Implementation**:
+```go
+GetDPIApplications() ([]*DPIApplication, error)
+GetDPICategories() ([]*DPICategory, error)
+```
+
+**Files**: extend `dpi.go`
+
+---
+
+### B14. Pending devices (`GET /v1/pending-devices`)
+
+**Status**: Open
+
+**Data**: `macAddress`, `ipAddress`, `model`, `state`, `supported`, `firmwareVersion`, `firmwareUpdatable`, `features`.
+
+**Use case**: Adoption queue monitoring — see what devices are waiting to be adopted.
+
+**Implementation**: `GetPendingDevices() ([]*PendingDevice, error)`
+
+**Files**: extend `devices.go` or new `pending_devices.go`
+
+---
+
+### B15. Application info (`GET /v1/info`)
+
+**Status**: Open
+
+**Data**: `applicationVersion` string.
+
+**Use case**: Lightweight version check; complements `GetServerData()` which populates `ServerStatus`, after which `u.ServerStatus.MajorVersion()` returns the numeric major version (promoted to `u.MajorVersion()` via embedding, but requires `GetServerData()` to have been called first).
+
+**Implementation**: `GetIntegrationInfo() (*IntegrationInfo, error)`
+
+**Files**: `integration_sites.go` (same file as B0, trivially small)
+
+---
+
+### B16. Countries (`GET /v1/countries`)
+
+**Status**: Open
+
+**Data**: `code`, `name` per country.
+
+**Use case**: Reference data for geo-based firewall policy filters (region filter). Low priority.
+
+**Implementation**: `GetCountries() ([]*Country, error)`
+
+**Files**: `countries.go`
+
+---
+
+## Part B — Implementation order
+
+### Phase 0 (prerequisite)
+- **B0** — `GetIntegrationSites()` + `IntegrationSite` type
+
+### Phase 1 (high monitoring value, low complexity)
+- **B1** — Device statistics (CPU/mem/uptime)
+- **B2** — WiFi broadcasts (SSID inventory)
+- **B3** — Firewall zones (completes firewall policy context)
+- **B4** — ACL rules
+
+### Phase 2 (network topology)
+- **B5** — Networks (integration/v1)
+- **B6** — WAN interfaces
+- **B7** — VPN servers + site-to-site tunnels
+- **B8** — Switching topology (LAGs, MC-LAGs, stacks)
+- **B9** — DNS policies
+
+### Phase 3 (reference and config data)
+- **B10** — RADIUS profiles
+- **B11** — Traffic matching lists
+- **B12** — Hotspot vouchers
+- **B13** — DPI app/category catalogue
+- **B14** — Pending devices
+- **B15** — Application info
+- **B16** — Countries
+
+---
+
+## Part B — Implementation notes
+
+- **Auth**: Integration/v1 requires `X-API-Key` — cookie auth returns 401. Every B-phase getter must guard with an early return when `u.APIKey == ""` (a new sentinel `ErrAPIKeyRequired` should be added). The `setHeaders` helper already sends the key when present; no transport changes needed.
+- **Pagination**: Integration/v1 list responses use `{offset, limit, count, totalCount, data}` — a different envelope from the legacy `{meta, data}` that `GetData` is shaped for. Paginated getters must use `GetJSON` + a shared integration-pagination helper that loops until `offset+count >= totalCount`, rather than `GetData`.
+- **Global vs. per-site**: Endpoints without a `{siteId}` segment (B13–B16) take no site parameter. Don't add `*IntegrationSite` to these getters.
+- **Path constants**: All integration/v1 path constants go in `types.go` under a new `// Integration/v1 API paths` comment block, following the same naming convention (`APIIntegration*Path`).
+- **Interface**: Every new getter must be added to `UnifiClient` in `types.go` and implemented in `mocks/`.
+- **Write operations excluded**: POST/PUT/DELETE/PATCH are out of scope — the library is read-only by design.
+- **Availability gate**: Integration/v1 requires Network 9.3.43+. Callers should check `u.ServerStatus.MajorVersion() >= 9` (after `GetServerData()`) before calling integration/v1 getters, or handle `ErrEndpointNotFound` gracefully if the endpoint is absent on older controllers.

--- a/acl_rules.go
+++ b/acl_rules.go
@@ -1,6 +1,28 @@
 package unifi
 
+import "fmt"
+
 // GetACLRules returns access control rules for a site.
-func (u *Unifi) GetACLRules(_ *IntegrationSite) ([]*ACLRule, error) {
-	return nil, nil
+func (u *Unifi) GetACLRules(site *IntegrationSite) ([]*ACLRule, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for ACL rules, site %s", site.Name)
+
+	path := fmt.Sprintf(APIACLRulesPath, site.ID)
+
+	items, err := getIntegrationList[ACLRule](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching ACL rules for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*ACLRule, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/acl_rules.go
+++ b/acl_rules.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetACLRules returns access control rules for a site.
+func (u *Unifi) GetACLRules(_ *IntegrationSite) ([]*ACLRule, error) {
+	return nil, nil
+}

--- a/acl_rules.go
+++ b/acl_rules.go
@@ -4,8 +4,16 @@ import "fmt"
 
 // GetACLRules returns access control rules for a site.
 func (u *Unifi) GetACLRules(site *IntegrationSite) ([]*ACLRule, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for ACL rules, site %s", site.Name)

--- a/acl_rules_test.go
+++ b/acl_rules_test.go
@@ -1,0 +1,17 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestACLRule(t *testing.T) {
+	t.Parallel()
+
+	var r unifi.ACLRule
+
+	require.NoError(t, gofakeit.Struct(&r))
+}

--- a/countries.go
+++ b/countries.go
@@ -1,6 +1,20 @@
 package unifi
 
+import "fmt"
+
 // GetCountries returns the list of countries for geo-based firewall filters (global, no site).
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetCountries() ([]*Country, error) {
-	return nil, nil
+	items, err := getIntegrationList[Country](u, APICountriesPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching countries: %w", err)
+	}
+
+	result := make([]*Country, len(items))
+
+	for i := range items {
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/countries.go
+++ b/countries.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetCountries returns the list of countries for geo-based firewall filters (global, no site).
+func (u *Unifi) GetCountries() ([]*Country, error) {
+	return nil, nil
+}

--- a/countries_test.go
+++ b/countries_test.go
@@ -1,0 +1,17 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestCountry(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.Country
+
+	require.NoError(t, gofakeit.Struct(&s))
+}

--- a/dns_policies.go
+++ b/dns_policies.go
@@ -1,0 +1,29 @@
+package unifi
+
+import "fmt"
+
+// GetDNSPolicies returns DNS policies for a site.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetDNSPolicies(site *IntegrationSite) ([]*DNSPolicy, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration API for DNS policy data, site %s", site.Name)
+
+	path := fmt.Sprintf(APIDNSPoliciesPath, site.ID)
+
+	items, err := getIntegrationList[DNSPolicy](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching DNS policies for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*DNSPolicy, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}

--- a/dns_policies.go
+++ b/dns_policies.go
@@ -5,8 +5,16 @@ import "fmt"
 // GetDNSPolicies returns DNS policies for a site.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetDNSPolicies(site *IntegrationSite) ([]*DNSPolicy, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration API for DNS policy data, site %s", site.Name)

--- a/dns_policies.go
+++ b/dns_policies.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetDNSPolicies returns DNS policies for a site.
+func (u *Unifi) GetDNSPolicies(_ *IntegrationSite) ([]*DNSPolicy, error) {
+	return nil, nil
+}

--- a/dns_policies_test.go
+++ b/dns_policies_test.go
@@ -1,0 +1,17 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestDNSPolicy(t *testing.T) {
+	t.Parallel()
+
+	var p unifi.DNSPolicy
+
+	require.NoError(t, gofakeit.Struct(&p))
+}

--- a/dpi_catalogue.go
+++ b/dpi_catalogue.go
@@ -1,0 +1,11 @@
+package unifi
+
+// GetDPIApplications returns the DPI application reference catalogue (global, no site).
+func (u *Unifi) GetDPIApplications() ([]*DPIApplication, error) {
+	return nil, nil
+}
+
+// GetDPICategories returns the DPI category reference catalogue (global, no site).
+func (u *Unifi) GetDPICategories() ([]*DPICategory, error) {
+	return nil, nil
+}

--- a/dpi_catalogue.go
+++ b/dpi_catalogue.go
@@ -1,11 +1,37 @@
 package unifi
 
+import "fmt"
+
 // GetDPIApplications returns the DPI application reference catalogue (global, no site).
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetDPIApplications() ([]*DPIApplication, error) {
-	return nil, nil
+	items, err := getIntegrationList[DPIApplication](u, APIDPIApplicationsPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching DPI applications: %w", err)
+	}
+
+	result := make([]*DPIApplication, len(items))
+
+	for i := range items {
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }
 
 // GetDPICategories returns the DPI category reference catalogue (global, no site).
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetDPICategories() ([]*DPICategory, error) {
-	return nil, nil
+	items, err := getIntegrationList[DPICategory](u, APIDPICategoriesPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching DPI categories: %w", err)
+	}
+
+	result := make([]*DPICategory, len(items))
+
+	for i := range items {
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/dpi_catalogue_test.go
+++ b/dpi_catalogue_test.go
@@ -1,0 +1,25 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestDPIApplication(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.DPIApplication
+
+	require.NoError(t, gofakeit.Struct(&s))
+}
+
+func TestDPICategory(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.DPICategory
+
+	require.NoError(t, gofakeit.Struct(&s))
+}

--- a/firewall_zones.go
+++ b/firewall_zones.go
@@ -4,8 +4,16 @@ import "fmt"
 
 // GetFirewallZones returns firewall zones for a site. Zone IDs appear in firewall policies.
 func (u *Unifi) GetFirewallZones(site *IntegrationSite) ([]*FirewallZone, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for firewall zones, site %s", site.Name)

--- a/firewall_zones.go
+++ b/firewall_zones.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetFirewallZones returns firewall zones for a site.
+func (u *Unifi) GetFirewallZones(_ *IntegrationSite) ([]*FirewallZone, error) {
+	return nil, nil
+}

--- a/firewall_zones.go
+++ b/firewall_zones.go
@@ -1,6 +1,28 @@
 package unifi
 
-// GetFirewallZones returns firewall zones for a site.
-func (u *Unifi) GetFirewallZones(_ *IntegrationSite) ([]*FirewallZone, error) {
-	return nil, nil
+import "fmt"
+
+// GetFirewallZones returns firewall zones for a site. Zone IDs appear in firewall policies.
+func (u *Unifi) GetFirewallZones(site *IntegrationSite) ([]*FirewallZone, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for firewall zones, site %s", site.Name)
+
+	path := fmt.Sprintf(APIFirewallZonesPath, site.ID)
+
+	items, err := getIntegrationList[FirewallZone](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching firewall zones for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*FirewallZone, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/firewall_zones_test.go
+++ b/firewall_zones_test.go
@@ -1,0 +1,25 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestFirewallZone(t *testing.T) {
+	t.Parallel()
+
+	var z unifi.FirewallZone
+
+	require.NoError(t, gofakeit.Struct(&z))
+}
+
+func TestFirewallZoneMetadata(t *testing.T) {
+	t.Parallel()
+
+	var m unifi.FirewallZoneMetadata
+
+	require.NoError(t, gofakeit.Struct(&m))
+}

--- a/hotspot_vouchers.go
+++ b/hotspot_vouchers.go
@@ -4,8 +4,16 @@ import "fmt"
 
 // GetHotspotVouchers returns guest portal vouchers for a site.
 func (u *Unifi) GetHotspotVouchers(site *IntegrationSite) ([]*HotspotVoucher, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for hotspot vouchers, site %s", site.Name)

--- a/hotspot_vouchers.go
+++ b/hotspot_vouchers.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetHotspotVouchers returns guest portal vouchers for a site.
+func (u *Unifi) GetHotspotVouchers(_ *IntegrationSite) ([]*HotspotVoucher, error) {
+	return nil, nil
+}

--- a/hotspot_vouchers.go
+++ b/hotspot_vouchers.go
@@ -1,0 +1,28 @@
+package unifi
+
+import "fmt"
+
+// GetHotspotVouchers returns guest portal vouchers for a site.
+func (u *Unifi) GetHotspotVouchers(site *IntegrationSite) ([]*HotspotVoucher, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for hotspot vouchers, site %s", site.Name)
+
+	path := fmt.Sprintf(APIHotspotVouchersPath, site.ID)
+
+	items, err := getIntegrationList[HotspotVoucher](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching hotspot vouchers for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*HotspotVoucher, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}

--- a/hotspot_vouchers_test.go
+++ b/hotspot_vouchers_test.go
@@ -1,0 +1,17 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestHotspotVoucher(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.HotspotVoucher
+
+	require.NoError(t, gofakeit.Struct(&s))
+}

--- a/integration.go
+++ b/integration.go
@@ -16,38 +16,131 @@ type integrationPage[T any] struct {
 
 // getIntegrationList fetches all pages from an Integration/v1 list endpoint.
 // path must not include offset/limit query parameters.
+// Returns nil, nil for an empty result set (totalCount=0), following Go convention.
 func getIntegrationList[T any](u *Unifi, path string) ([]T, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if u.APIKey == "" {
 		return nil, ErrAPIKeyRequired
 	}
 
+	u.DebugLog("Polling Integration/v1 list %s", path)
+
 	const pageSize = 200
 
-	var all []T
+	var (
+		all             []T
+		totalCount      int
+		driftCount      int // incremented for every page where totalCount changes from the first-page value
+		driftOffset     int // first offset where drift was recorded; always >0 (drift only occurs in else-if when offset!=0); 0 means no drift
+		driftTotalCount int // the totalCount value the server reported at driftOffset
+	)
 
 	offset := 0
 
+	// The loop is bounded: offset advances by page.Count each iteration and exits when
+	// offset >= totalCount. totalCount is captured from the first page; if the server grows
+	// totalCount after a full first page is already returned, the loop exits without a second
+	// page to compare against and drift goes undetected — inherent in snapshot-based pagination.
+	// The page.Count == 0 guard handles servers that return an empty page prematurely.
 	for {
 		pagedPath := fmt.Sprintf("%s?offset=%d&limit=%d", path, offset, pageSize)
 
 		body, err := u.GetJSON(pagedPath)
 		if err != nil {
-			return nil, err
+			u.ErrorLog("integration page %s: request failed: %v", pagedPath, err)
+
+			return nil, fmt.Errorf("fetching integration page %s: %w", pagedPath, err)
 		}
+
+		u.DebugLog("Fetched integration page %s (%d bytes)", pagedPath, len(body))
 
 		var page integrationPage[T]
 
 		if err := json.Unmarshal(body, &page); err != nil {
-			return nil, fmt.Errorf("parsing integration response: %w", err)
+			// DebugLog rather than ErrorLog: the returned error is the actionable signal for callers;
+			// the body is supplementary context (may be a large HTML proxy-error page) only needed
+			// when actively debugging. %.512s is a byte-boundary truncation and may split a multi-byte
+			// UTF-8 sequence, but JSON responses are ASCII-safe enough for diagnostic use.
+			u.DebugLog("integration list %s: failed response body (first 512 bytes): %.512s", pagedPath, body)
+
+			return nil, fmt.Errorf("parsing integration response from %s: %w", pagedPath, err)
+		}
+
+		// A per-page count mismatch is a protocol violation distinct from the multi-page
+		// completeness failure that ErrIncompleteResults signals: the server contradicted
+		// itself within a single response rather than across pages. Not wrapping
+		// ErrIncompleteResults is intentional — callers distinguish the two modes by
+		// checking errors.Is(err, ErrIncompleteResults): false means per-page violation,
+		// true means multi-page count mismatch.
+		if page.Count != len(page.Data) {
+			u.ErrorLog("integration page %s: server reported count=%d but returned %d items", pagedPath, page.Count, len(page.Data))
+
+			return nil, fmt.Errorf("integration page %s: server reported count=%d but returned %d items", pagedPath, page.Count, len(page.Data))
+		}
+
+		// Check for invalid totalCount before drift detection: a negative value on a later
+		// page must return an error rather than record a spurious driftOffset.
+		if page.TotalCount < 0 {
+			u.ErrorLog("integration page %s: server returned negative totalCount=%d", pagedPath, page.TotalCount)
+
+			return nil, fmt.Errorf("integration page %s: server returned negative totalCount=%d", pagedPath, page.TotalCount)
+		}
+
+		if offset == 0 {
+			totalCount = page.TotalCount
+		} else if page.TotalCount != totalCount {
+			driftCount++
+
+			if driftOffset == 0 {
+				driftOffset = offset
+				driftTotalCount = page.TotalCount // logged at end with final counts for full context
+			}
 		}
 
 		all = append(all, page.Data...)
 		offset += page.Count
 
-		if offset >= page.TotalCount || page.Count == 0 {
+		if page.Count == 0 {
+			// "integration list" (path) rather than "integration page" (pagedPath) is intentional:
+			// this is a list-level event; the offset field already identifies the triggering page.
+			// ErrIncompleteResults covers both early-exit and final-count-mismatch paths; callers
+			// that need to distinguish them can inspect the error message from the preceding ErrorLog.
+			if offset < totalCount {
+				u.ErrorLog("integration list %s: server returned count=0 at offset %d but only %d/%d items fetched; stopping early", path, offset, len(all), totalCount)
+
+				return nil, ErrIncompleteResults
+			}
+
+			u.DebugLog("integration list %s: server returned count=0 with totalCount=%d; done", path, totalCount)
+
+			break
+		}
+
+		if offset >= totalCount {
 			break
 		}
 	}
+
+	if len(all) != totalCount {
+		if driftCount > 0 {
+			u.ErrorLog("integration list %s: totalCount drifted %d time(s), first at offset %d from %d to %d; fetched %d items", path, driftCount, driftOffset, totalCount, driftTotalCount, len(all))
+		} else {
+			u.ErrorLog("integration list %s: fetched %d items but server reported totalCount=%d", path, len(all), totalCount)
+		}
+
+		return nil, ErrIncompleteResults
+	}
+
+	if driftCount > 0 {
+		// DebugLog rather than ErrorLog: all items were fetched successfully; drift that resolved
+		// is informational, not a failure. ErrorLog here would produce false production alerts.
+		u.DebugLog("integration list %s: totalCount drifted %d time(s) but resolved; first drift at offset %d from %d to %d", path, driftCount, driftOffset, totalCount, driftTotalCount)
+	}
+
+	u.DebugLog("Fetched %d/%d items from %s", len(all), totalCount, path)
 
 	return all, nil
 }

--- a/integration.go
+++ b/integration.go
@@ -17,7 +17,7 @@ type integrationPage[T any] struct {
 // getIntegrationList fetches all pages from an Integration/v1 list endpoint.
 // path must not include offset/limit query parameters.
 func getIntegrationList[T any](u *Unifi, path string) ([]T, error) {
-	if u.Config.APIKey == "" {
+	if u.APIKey == "" {
 		return nil, ErrAPIKeyRequired
 	}
 

--- a/integration.go
+++ b/integration.go
@@ -1,0 +1,53 @@
+package unifi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// integrationPage is the JSON envelope for Integration/v1 paginated list responses.
+type integrationPage[T any] struct {
+	Count      int `json:"count"`
+	Data       []T `json:"data"`
+	Limit      int `json:"limit"`
+	Offset     int `json:"offset"`
+	TotalCount int `json:"totalCount"`
+}
+
+// getIntegrationList fetches all pages from an Integration/v1 list endpoint.
+// path must not include offset/limit query parameters.
+func getIntegrationList[T any](u *Unifi, path string) ([]T, error) {
+	if u.APIKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	const pageSize = 200
+
+	var all []T
+
+	offset := 0
+
+	for {
+		pagedPath := fmt.Sprintf("%s?offset=%d&limit=%d", path, offset, pageSize)
+
+		body, err := u.GetJSON(pagedPath)
+		if err != nil {
+			return nil, err
+		}
+
+		var page integrationPage[T]
+
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("parsing integration response: %w", err)
+		}
+
+		all = append(all, page.Data...)
+		offset += page.Count
+
+		if offset >= page.TotalCount || page.Count == 0 {
+			break
+		}
+	}
+
+	return all, nil
+}

--- a/integration.go
+++ b/integration.go
@@ -1,0 +1,53 @@
+package unifi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// integrationPage is the JSON envelope for Integration/v1 paginated list responses.
+type integrationPage[T any] struct {
+	Count      int `json:"count"`
+	Data       []T `json:"data"`
+	Limit      int `json:"limit"`
+	Offset     int `json:"offset"`
+	TotalCount int `json:"totalCount"`
+}
+
+// getIntegrationList fetches all pages from an Integration/v1 list endpoint.
+// path must not include offset/limit query parameters.
+func getIntegrationList[T any](u *Unifi, path string) ([]T, error) {
+	if u.Config.APIKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	const pageSize = 200
+
+	var all []T
+
+	offset := 0
+
+	for {
+		pagedPath := fmt.Sprintf("%s?offset=%d&limit=%d", path, offset, pageSize)
+
+		body, err := u.GetJSON(pagedPath)
+		if err != nil {
+			return nil, err
+		}
+
+		var page integrationPage[T]
+
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("parsing integration response: %w", err)
+		}
+
+		all = append(all, page.Data...)
+		offset += page.Count
+
+		if offset >= page.TotalCount || page.Count == 0 {
+			break
+		}
+	}
+
+	return all, nil
+}

--- a/integration_devices.go
+++ b/integration_devices.go
@@ -7,6 +7,10 @@ import (
 
 // GetIntegrationDeviceStats returns statistics for a single device from the Integration/v1 API.
 func (u *Unifi) GetIntegrationDeviceStats(site *IntegrationSite, deviceID string) (*IntegrationDeviceStats, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if u.APIKey == "" {
 		return nil, ErrAPIKeyRequired
 	}
@@ -14,6 +18,16 @@ func (u *Unifi) GetIntegrationDeviceStats(site *IntegrationSite, deviceID string
 	if site == nil {
 		return nil, ErrNoSiteProvided
 	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
+	}
+
+	if deviceID == "" {
+		return nil, fmt.Errorf("deviceID must not be empty")
+	}
+
+	u.DebugLog("Polling Integration/v1 for device stats, site %s device %s", site.Name, deviceID)
 
 	path := fmt.Sprintf(APIIntegrationDeviceStatsPath, site.ID, deviceID)
 
@@ -32,7 +46,12 @@ func (u *Unifi) GetIntegrationDeviceStats(site *IntegrationSite, deviceID string
 }
 
 // GetAllIntegrationDeviceStats returns statistics for all devices in a site.
+// If fetching stats for a device fails, partial results collected so far are returned alongside the error.
 func (u *Unifi) GetAllIntegrationDeviceStats(site *IntegrationSite) ([]*IntegrationDeviceStats, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if u.APIKey == "" {
 		return nil, ErrAPIKeyRequired
 	}
@@ -40,6 +59,12 @@ func (u *Unifi) GetAllIntegrationDeviceStats(site *IntegrationSite) ([]*Integrat
 	if site == nil {
 		return nil, ErrNoSiteProvided
 	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
+	}
+
+	u.DebugLog("Polling Integration/v1 for all device stats, site %s", site.Name)
 
 	type integrationDeviceID struct {
 		ID string `json:"id"`
@@ -54,13 +79,32 @@ func (u *Unifi) GetAllIntegrationDeviceStats(site *IntegrationSite) ([]*Integrat
 
 	result := make([]*IntegrationDeviceStats, 0, len(devices))
 
+	skipped := 0
+
 	for _, dev := range devices {
+		if dev.ID == "" {
+			skipped++
+
+			continue
+		}
+
 		stats, err := u.GetIntegrationDeviceStats(site, dev.ID)
 		if err != nil {
-			return nil, err
+			// DebugLog provides supplementary context; the returned error is the primary signal for the caller.
+			if skipped > 0 {
+				u.DebugLog("Skipped %d/%d devices with empty IDs in site %s before error", skipped, len(devices), site.Name)
+			}
+
+			return result, fmt.Errorf("fetching stats for device %s in site %s: %w", dev.ID, site.Name, err)
 		}
 
 		result = append(result, stats)
+	}
+
+	// DebugLog rather than ErrorLog: an empty device ID is a server data quality issue (e.g.,
+	// a device mid-adoption), not a code error. ErrorLog would produce false production alerts.
+	if skipped > 0 {
+		u.DebugLog("Skipped %d/%d devices with empty IDs in site %s", skipped, len(devices), site.Name)
 	}
 
 	return result, nil

--- a/integration_devices.go
+++ b/integration_devices.go
@@ -1,11 +1,67 @@
 package unifi
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // GetIntegrationDeviceStats returns statistics for a single device from the Integration/v1 API.
-func (u *Unifi) GetIntegrationDeviceStats(_ *IntegrationSite, _ string) (*IntegrationDeviceStats, error) {
-	return nil, nil
+func (u *Unifi) GetIntegrationDeviceStats(site *IntegrationSite, deviceID string) (*IntegrationDeviceStats, error) {
+	if u.APIKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	path := fmt.Sprintf(APIIntegrationDeviceStatsPath, site.ID, deviceID)
+
+	body, err := u.GetJSON(path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching device stats for site %s device %s: %w", site.Name, deviceID, err)
+	}
+
+	var stats IntegrationDeviceStats
+
+	if err := json.Unmarshal(body, &stats); err != nil {
+		return nil, fmt.Errorf("parsing device stats for site %s device %s: %w", site.Name, deviceID, err)
+	}
+
+	return &stats, nil
 }
 
 // GetAllIntegrationDeviceStats returns statistics for all devices in a site.
-func (u *Unifi) GetAllIntegrationDeviceStats(_ *IntegrationSite) ([]*IntegrationDeviceStats, error) {
-	return nil, nil
+func (u *Unifi) GetAllIntegrationDeviceStats(site *IntegrationSite) ([]*IntegrationDeviceStats, error) {
+	if u.APIKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	type integrationDeviceID struct {
+		ID string `json:"id"`
+	}
+
+	devPath := fmt.Sprintf(APIIntegrationDevicesPath, site.ID)
+
+	devices, err := getIntegrationList[integrationDeviceID](u, devPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching device list for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*IntegrationDeviceStats, 0, len(devices))
+
+	for _, dev := range devices {
+		stats, err := u.GetIntegrationDeviceStats(site, dev.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, stats)
+	}
+
+	return result, nil
 }

--- a/integration_devices.go
+++ b/integration_devices.go
@@ -1,0 +1,11 @@
+package unifi
+
+// GetIntegrationDeviceStats returns statistics for a single device from the Integration/v1 API.
+func (u *Unifi) GetIntegrationDeviceStats(_ *IntegrationSite, _ string) (*IntegrationDeviceStats, error) {
+	return nil, nil
+}
+
+// GetAllIntegrationDeviceStats returns statistics for all devices in a site.
+func (u *Unifi) GetAllIntegrationDeviceStats(_ *IntegrationSite) ([]*IntegrationDeviceStats, error) {
+	return nil, nil
+}

--- a/integration_devices_test.go
+++ b/integration_devices_test.go
@@ -1,0 +1,33 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestIntegrationDeviceStats(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.IntegrationDeviceStats
+
+	require.NoError(t, gofakeit.Struct(&s))
+}
+
+func TestIntegrationDeviceRadioStats(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.IntegrationDeviceRadioStats
+
+	require.NoError(t, gofakeit.Struct(&s))
+}
+
+func TestIntegrationDeviceUplinkStats(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.IntegrationDeviceUplinkStats
+
+	require.NoError(t, gofakeit.Struct(&s))
+}

--- a/integration_networks.go
+++ b/integration_networks.go
@@ -5,8 +5,16 @@ import "fmt"
 // GetIntegrationNetworks returns networks for a site from the Integration/v1 API.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetIntegrationNetworks(site *IntegrationSite) ([]*IntegrationNetwork, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for networks, site %s", site.Name)

--- a/integration_networks.go
+++ b/integration_networks.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetIntegrationNetworks returns networks for a site from the Integration/v1 API.
+func (u *Unifi) GetIntegrationNetworks(_ *IntegrationSite) ([]*IntegrationNetwork, error) {
+	return nil, nil
+}

--- a/integration_networks.go
+++ b/integration_networks.go
@@ -1,6 +1,29 @@
 package unifi
 
+import "fmt"
+
 // GetIntegrationNetworks returns networks for a site from the Integration/v1 API.
-func (u *Unifi) GetIntegrationNetworks(_ *IntegrationSite) ([]*IntegrationNetwork, error) {
-	return nil, nil
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetIntegrationNetworks(site *IntegrationSite) ([]*IntegrationNetwork, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for networks, site %s", site.Name)
+
+	path := fmt.Sprintf(APIIntegrationNetworksPath, site.ID)
+
+	items, err := getIntegrationList[IntegrationNetwork](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching integration networks for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*IntegrationNetwork, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/integration_networks_test.go
+++ b/integration_networks_test.go
@@ -1,0 +1,20 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestIntegrationNetwork(t *testing.T) {
+	t.Parallel()
+
+	var n unifi.IntegrationNetwork
+
+	err := gofakeit.Struct(&n)
+	require.NoError(t, err)
+	require.NotEmpty(t, n.ID)
+	require.NotEmpty(t, n.Name)
+}

--- a/integration_sites.go
+++ b/integration_sites.go
@@ -26,6 +26,10 @@ func (u *Unifi) GetIntegrationSites() ([]*IntegrationSite, error) {
 // GetIntegrationInfo returns application version info from the Integration/v1 API.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetIntegrationInfo() (*IntegrationInfo, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if u.APIKey == "" {
 		return nil, ErrAPIKeyRequired
 	}

--- a/integration_sites.go
+++ b/integration_sites.go
@@ -26,7 +26,7 @@ func (u *Unifi) GetIntegrationSites() ([]*IntegrationSite, error) {
 // GetIntegrationInfo returns application version info from the Integration/v1 API.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetIntegrationInfo() (*IntegrationInfo, error) {
-	if u.Config.APIKey == "" {
+	if u.APIKey == "" {
 		return nil, ErrAPIKeyRequired
 	}
 

--- a/integration_sites.go
+++ b/integration_sites.go
@@ -1,0 +1,45 @@
+package unifi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetIntegrationSites returns all sites from the Integration/v1 API.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+// Use InternalReference to cross-reference with the legacy Site.Name field.
+func (u *Unifi) GetIntegrationSites() ([]*IntegrationSite, error) {
+	sites, err := getIntegrationList[IntegrationSite](u, APIIntegrationSitesPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching integration sites: %w", err)
+	}
+
+	result := make([]*IntegrationSite, len(sites))
+
+	for i := range sites {
+		result[i] = &sites[i]
+	}
+
+	return result, nil
+}
+
+// GetIntegrationInfo returns application version info from the Integration/v1 API.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetIntegrationInfo() (*IntegrationInfo, error) {
+	if u.APIKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	body, err := u.GetJSON(APIIntegrationInfoPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching integration info: %w", err)
+	}
+
+	var info IntegrationInfo
+
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("parsing integration info: %w", err)
+	}
+
+	return &info, nil
+}

--- a/integration_sites.go
+++ b/integration_sites.go
@@ -1,0 +1,45 @@
+package unifi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetIntegrationSites returns all sites from the Integration/v1 API.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+// Use InternalReference to cross-reference with the legacy Site.Name field.
+func (u *Unifi) GetIntegrationSites() ([]*IntegrationSite, error) {
+	sites, err := getIntegrationList[IntegrationSite](u, APIIntegrationSitesPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching integration sites: %w", err)
+	}
+
+	result := make([]*IntegrationSite, len(sites))
+
+	for i := range sites {
+		result[i] = &sites[i]
+	}
+
+	return result, nil
+}
+
+// GetIntegrationInfo returns application version info from the Integration/v1 API.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetIntegrationInfo() (*IntegrationInfo, error) {
+	if u.Config.APIKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	body, err := u.GetJSON(APIIntegrationInfoPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching integration info: %w", err)
+	}
+
+	var info IntegrationInfo
+
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("parsing integration info: %w", err)
+	}
+
+	return &info, nil
+}

--- a/integration_wans.go
+++ b/integration_wans.go
@@ -1,6 +1,29 @@
 package unifi
 
-// GetIntegrationWANs returns WAN interface identifiers for a site.
-func (u *Unifi) GetIntegrationWANs(_ *IntegrationSite) ([]*IntegrationWAN, error) {
-	return nil, nil
+import "fmt"
+
+// GetIntegrationWANs returns WAN interface identifiers for a site from the Integration/v1 API.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetIntegrationWANs(site *IntegrationSite) ([]*IntegrationWAN, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for WAN interfaces, site %s", site.Name)
+
+	path := fmt.Sprintf(APIIntegrationWANsPath, site.ID)
+
+	items, err := getIntegrationList[IntegrationWAN](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching integration WANs for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*IntegrationWAN, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/integration_wans.go
+++ b/integration_wans.go
@@ -5,8 +5,16 @@ import "fmt"
 // GetIntegrationWANs returns WAN interface identifiers for a site from the Integration/v1 API.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetIntegrationWANs(site *IntegrationSite) ([]*IntegrationWAN, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for WAN interfaces, site %s", site.Name)

--- a/integration_wans.go
+++ b/integration_wans.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetIntegrationWANs returns WAN interface identifiers for a site.
+func (u *Unifi) GetIntegrationWANs(_ *IntegrationSite) ([]*IntegrationWAN, error) {
+	return nil, nil
+}

--- a/integration_wans_test.go
+++ b/integration_wans_test.go
@@ -1,0 +1,20 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestIntegrationWAN(t *testing.T) {
+	t.Parallel()
+
+	var w unifi.IntegrationWAN
+
+	err := gofakeit.Struct(&w)
+	require.NoError(t, err)
+	require.NotEmpty(t, w.ID)
+	require.NotEmpty(t, w.Name)
+}

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -784,3 +784,63 @@ func (m *MockUnifi) GetMagicSiteToSiteVPNSite(_ *unifi.Site) ([]*unifi.MagicSite
 
 	return results, nil
 }
+
+// GetWANStatus returns the WAN interface status for a single site.
+func (m *MockUnifi) GetWANStatus(_ *unifi.Site) (*unifi.WANStatus, error) {
+	var w unifi.WANStatus
+
+	err := gofakeit.Struct(&w)
+	if err != nil {
+		return &w, err
+	}
+
+	return &w, nil
+}
+
+// GetUPSDeviceList returns the list of UPS device selectors for a single site.
+func (m *MockUnifi) GetUPSDeviceList(_ *unifi.Site) ([]*unifi.UPSDeviceSelector, error) {
+	results := make([]*unifi.UPSDeviceSelector, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var d unifi.UPSDeviceSelector
+
+		err := gofakeit.Struct(&d)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &d
+	}
+
+	return results, nil
+}
+
+// GetPortForwards returns port forwarding rules for a single site.
+func (m *MockUnifi) GetPortForwards(_ *unifi.Site) ([]*unifi.PortForward, error) {
+	results := make([]*unifi.PortForward, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var p unifi.PortForward
+
+		err := gofakeit.Struct(&p)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &p
+	}
+
+	return results, nil
+}
+
+// GetSSLCertificate returns the active SSL certificate info for a single site.
+func (m *MockUnifi) GetSSLCertificate(_ *unifi.Site) (*unifi.SSLCertificate, error) {
+	var c unifi.SSLCertificate
+
+	err := gofakeit.Struct(&c)
+	if err != nil {
+		return &c, err
+	}
+
+	return &c, nil
+}

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -784,3 +784,447 @@ func (m *MockUnifi) GetMagicSiteToSiteVPNSite(_ *unifi.Site) ([]*unifi.MagicSite
 
 	return results, nil
 }
+
+// GetIntegrationSites returns all sites from the Integration/v1 API.
+func (m *MockUnifi) GetIntegrationSites() ([]*unifi.IntegrationSite, error) {
+	results := make([]*unifi.IntegrationSite, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.IntegrationSite
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetIntegrationInfo returns application version info from the Integration/v1 API.
+func (m *MockUnifi) GetIntegrationInfo() (*unifi.IntegrationInfo, error) {
+	var a unifi.IntegrationInfo
+
+	err := gofakeit.Struct(&a)
+	if err != nil {
+		return nil, err
+	}
+
+	return &a, nil
+}
+
+// GetIntegrationDeviceStats returns statistics for a single device.
+func (m *MockUnifi) GetIntegrationDeviceStats(_ *unifi.IntegrationSite, _ string) (*unifi.IntegrationDeviceStats, error) {
+	var s unifi.IntegrationDeviceStats
+
+	err := gofakeit.Struct(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+// GetAllIntegrationDeviceStats returns statistics for all devices in a site.
+func (m *MockUnifi) GetAllIntegrationDeviceStats(_ *unifi.IntegrationSite) ([]*unifi.IntegrationDeviceStats, error) {
+	results := make([]*unifi.IntegrationDeviceStats, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.IntegrationDeviceStats
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetWifiBroadcasts returns WiFi broadcast configurations for a site.
+func (m *MockUnifi) GetWifiBroadcasts(_ *unifi.IntegrationSite) ([]*unifi.WifiBroadcast, error) {
+	results := make([]*unifi.WifiBroadcast, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.WifiBroadcast
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetFirewallZones returns firewall zones for a site.
+func (m *MockUnifi) GetFirewallZones(_ *unifi.IntegrationSite) ([]*unifi.FirewallZone, error) {
+	results := make([]*unifi.FirewallZone, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.FirewallZone
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetACLRules returns access control rules for a site.
+func (m *MockUnifi) GetACLRules(_ *unifi.IntegrationSite) ([]*unifi.ACLRule, error) {
+	results := make([]*unifi.ACLRule, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.ACLRule
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetIntegrationNetworks returns networks for a site from the Integration/v1 API.
+func (m *MockUnifi) GetIntegrationNetworks(_ *unifi.IntegrationSite) ([]*unifi.IntegrationNetwork, error) {
+	results := make([]*unifi.IntegrationNetwork, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.IntegrationNetwork
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetIntegrationWANs returns WAN interface identifiers for a site.
+func (m *MockUnifi) GetIntegrationWANs(_ *unifi.IntegrationSite) ([]*unifi.IntegrationWAN, error) {
+	results := make([]*unifi.IntegrationWAN, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.IntegrationWAN
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetVPNServers returns VPN server configurations for a site.
+func (m *MockUnifi) GetVPNServers(_ *unifi.IntegrationSite) ([]*unifi.VPNServer, error) {
+	results := make([]*unifi.VPNServer, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.VPNServer
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetSiteToSiteTunnels returns site-to-site VPN tunnel configurations for a site.
+func (m *MockUnifi) GetSiteToSiteTunnels(_ *unifi.IntegrationSite) ([]*unifi.SiteToSiteTunnel, error) {
+	results := make([]*unifi.SiteToSiteTunnel, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.SiteToSiteTunnel
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetLAGs returns link aggregation group configurations for a site.
+func (m *MockUnifi) GetLAGs(_ *unifi.IntegrationSite) ([]*unifi.LAG, error) {
+	results := make([]*unifi.LAG, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.LAG
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetMCLAGDomains returns multi-chassis LAG domain configurations for a site.
+func (m *MockUnifi) GetMCLAGDomains(_ *unifi.IntegrationSite) ([]*unifi.MCLAGDomain, error) {
+	results := make([]*unifi.MCLAGDomain, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.MCLAGDomain
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetSwitchStacks returns switch stack configurations for a site.
+func (m *MockUnifi) GetSwitchStacks(_ *unifi.IntegrationSite) ([]*unifi.SwitchStack, error) {
+	results := make([]*unifi.SwitchStack, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.SwitchStack
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetDNSPolicies returns DNS policies for a site.
+func (m *MockUnifi) GetDNSPolicies(_ *unifi.IntegrationSite) ([]*unifi.DNSPolicy, error) {
+	results := make([]*unifi.DNSPolicy, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.DNSPolicy
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetRADIUSProfiles returns RADIUS authentication profiles for a site.
+func (m *MockUnifi) GetRADIUSProfiles(_ *unifi.IntegrationSite) ([]*unifi.RADIUSProfile, error) {
+	results := make([]*unifi.RADIUSProfile, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.RADIUSProfile
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetTrafficMatchingLists returns traffic matching lists for a site.
+func (m *MockUnifi) GetTrafficMatchingLists(_ *unifi.IntegrationSite) ([]*unifi.TrafficMatchingList, error) {
+	results := make([]*unifi.TrafficMatchingList, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.TrafficMatchingList
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetHotspotVouchers returns guest portal vouchers for a site.
+func (m *MockUnifi) GetHotspotVouchers(_ *unifi.IntegrationSite) ([]*unifi.HotspotVoucher, error) {
+	results := make([]*unifi.HotspotVoucher, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.HotspotVoucher
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetDPIApplications returns the DPI application reference catalogue (global, no site).
+func (m *MockUnifi) GetDPIApplications() ([]*unifi.DPIApplication, error) {
+	results := make([]*unifi.DPIApplication, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.DPIApplication
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetDPICategories returns the DPI category reference catalogue (global, no site).
+func (m *MockUnifi) GetDPICategories() ([]*unifi.DPICategory, error) {
+	results := make([]*unifi.DPICategory, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.DPICategory
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetPendingDevices returns devices waiting to be adopted (global, no site).
+func (m *MockUnifi) GetPendingDevices() ([]*unifi.PendingDevice, error) {
+	results := make([]*unifi.PendingDevice, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.PendingDevice
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetCountries returns the list of countries for geo-based firewall filters (global, no site).
+func (m *MockUnifi) GetCountries() ([]*unifi.Country, error) {
+	results := make([]*unifi.Country, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.Country
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetWANStatus returns WAN interface status for a site.
+func (m *MockUnifi) GetWANStatus(_ *unifi.Site) (*unifi.WANStatus, error) {
+	var w unifi.WANStatus
+
+	err := gofakeit.Struct(&w)
+	if err != nil {
+		return nil, err
+	}
+
+	return &w, nil
+}
+
+// GetUPSDeviceList returns UPS/PDU device selectors for a site.
+func (m *MockUnifi) GetUPSDeviceList(_ *unifi.Site) ([]*unifi.UPSDeviceSelector, error) {
+	results := make([]*unifi.UPSDeviceSelector, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.UPSDeviceSelector
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetPortForwards returns port forwarding rules for a site.
+func (m *MockUnifi) GetPortForwards(_ *unifi.Site) ([]*unifi.PortForward, error) {
+	results := make([]*unifi.PortForward, numItemsMocked)
+
+	for i := 0; i < numItemsMocked; i++ {
+		var a unifi.PortForward
+
+		err := gofakeit.Struct(&a)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = &a
+	}
+
+	return results, nil
+}
+
+// GetSSLCertificate returns SSL certificate information for a site.
+func (m *MockUnifi) GetSSLCertificate(_ *unifi.Site) (*unifi.SSLCertificate, error) {
+	var a unifi.SSLCertificate
+
+	err := gofakeit.Struct(&a)
+	if err != nil {
+		return nil, err
+	}
+
+	return &a, nil
+}

--- a/networks.go
+++ b/networks.go
@@ -60,4 +60,23 @@ type Network struct {
 	SiteID                 string   `fake:"{uuid}"                    json:"site_id"`
 	Vlan                   FlexInt  `json:"vlan"`
 	VlanEnabled            FlexBool `json:"vlan_enabled"`
+
+	// WAN failover
+	WANFailoverPriority FlexInt `json:"wan_failover_priority"`
+	WANLoadBalanceType  string  `json:"wan_load_balance_type"`
+
+	// IPv6
+	IPv6Enabled FlexBool `json:"ipv6_enabled"`
+
+	// VPN
+	SDWANRemoteSiteID string `json:"sdwan_remote_site_id"`
+	VPNType           string `json:"vpn_type"`
+
+	// Advanced DHCP
+	DhcpdNTPEnabled  FlexBool `json:"dhcpd_ntp_enabled"`
+	DhcpdWINSEnabled FlexBool `json:"dhcpd_wins_enabled"`
+
+	// Misc
+	FirewallZoneID string   `json:"firewall_zone_id"`
+	MDNSEnabled    FlexBool `json:"mdns_enabled"`
 }

--- a/pending_devices.go
+++ b/pending_devices.go
@@ -1,6 +1,20 @@
 package unifi
 
+import "fmt"
+
 // GetPendingDevices returns devices waiting to be adopted (global, no site).
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetPendingDevices() ([]*PendingDevice, error) {
-	return nil, nil
+	items, err := getIntegrationList[PendingDevice](u, APIPendingDevicesPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching pending devices: %w", err)
+	}
+
+	result := make([]*PendingDevice, len(items))
+
+	for i := range items {
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/pending_devices.go
+++ b/pending_devices.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetPendingDevices returns devices waiting to be adopted (global, no site).
+func (u *Unifi) GetPendingDevices() ([]*PendingDevice, error) {
+	return nil, nil
+}

--- a/pending_devices_test.go
+++ b/pending_devices_test.go
@@ -1,0 +1,17 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestPendingDevice(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.PendingDevice
+
+	require.NoError(t, gofakeit.Struct(&s))
+}

--- a/port_forwards.go
+++ b/port_forwards.go
@@ -1,0 +1,51 @@
+package unifi
+
+import "fmt"
+
+// PortForward represents a port forwarding rule from /api/s/{site}/rest/portforward.
+type PortForward struct {
+	ID      string   `fake:"{uuid}"                           json:"_id"`
+	Enabled FlexBool `json:"enabled"`
+	FwdIP   string   `fake:"{ipv4address}"                    json:"fwd"`
+	FwdPort string   `fake:"{number:1,65535}"                 json:"fwd_port"`
+	Name    string   `fake:"{buzzword}"                       json:"name"`
+	PfwdPf  string   `json:"pfwd_interface"`
+	Proto   string   `fake:"{randomstring:[tcp,udp,tcp_udp]}" json:"proto"`
+	SiteID  string   `fake:"{uuid}"                           json:"site_id"`
+	Src     string   `json:"src"`
+	DstPort string   `fake:"{number:1,65535}"                 json:"dst_port"`
+	Log     FlexBool `json:"log"`
+
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
+}
+
+// GetPortForwards returns port forwarding rules for a single site.
+// Uses the legacy API endpoint: GET /api/s/{site}/rest/portforward.
+func (u *Unifi) GetPortForwards(site *Site) ([]*PortForward, error) {
+	if site == nil || site.Name == "" {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Controller for port forwards, site %s", site.SiteName)
+
+	path := fmt.Sprintf(APIPortForwardPath, site.Name)
+
+	var response struct {
+		Data []PortForward `json:"data"`
+	}
+
+	if err := u.GetData(path, &response); err != nil {
+		return nil, fmt.Errorf("fetching port forwards for site %s: %w", site.SiteName, err)
+	}
+
+	result := make([]*PortForward, len(response.Data))
+
+	for i := range response.Data {
+		response.Data[i].SiteName = site.SiteName
+		response.Data[i].SourceName = u.URL
+		result[i] = &response.Data[i]
+	}
+
+	return result, nil
+}

--- a/port_forwards.go
+++ b/port_forwards.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetPortForwards returns port forwarding rules for a site.
+func (u *Unifi) GetPortForwards(_ *Site) ([]*PortForward, error) {
+	return nil, nil
+}

--- a/port_forwards_test.go
+++ b/port_forwards_test.go
@@ -1,0 +1,20 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestPortForwardStruct(t *testing.T) {
+	t.Parallel()
+
+	var p unifi.PortForward
+
+	err := gofakeit.Struct(&p)
+	require.NoError(t, err)
+	require.NotEmpty(t, p.ID)
+	require.NotEmpty(t, p.Name)
+}

--- a/radius_profiles.go
+++ b/radius_profiles.go
@@ -4,8 +4,16 @@ import "fmt"
 
 // GetRADIUSProfiles returns RADIUS authentication profiles for a site.
 func (u *Unifi) GetRADIUSProfiles(site *IntegrationSite) ([]*RADIUSProfile, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for RADIUS profiles, site %s", site.Name)

--- a/radius_profiles.go
+++ b/radius_profiles.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetRADIUSProfiles returns RADIUS authentication profiles for a site.
+func (u *Unifi) GetRADIUSProfiles(_ *IntegrationSite) ([]*RADIUSProfile, error) {
+	return nil, nil
+}

--- a/radius_profiles.go
+++ b/radius_profiles.go
@@ -1,0 +1,28 @@
+package unifi
+
+import "fmt"
+
+// GetRADIUSProfiles returns RADIUS authentication profiles for a site.
+func (u *Unifi) GetRADIUSProfiles(site *IntegrationSite) ([]*RADIUSProfile, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for RADIUS profiles, site %s", site.Name)
+
+	path := fmt.Sprintf(APIRADIUSProfilesPath, site.ID)
+
+	items, err := getIntegrationList[RADIUSProfile](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching RADIUS profiles for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*RADIUSProfile, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}

--- a/radius_profiles_test.go
+++ b/radius_profiles_test.go
@@ -1,0 +1,25 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestRADIUSProfileMetadata(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.RADIUSProfileMetadata
+
+	require.NoError(t, gofakeit.Struct(&s))
+}
+
+func TestRADIUSProfile(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.RADIUSProfile
+
+	require.NoError(t, gofakeit.Struct(&s))
+}

--- a/ssl_cert.go
+++ b/ssl_cert.go
@@ -1,0 +1,60 @@
+package unifi
+
+import "fmt"
+
+// SSLCertificate represents the active SSL certificate from /api/s/{site}/stat/active.
+type SSLCertificate struct {
+	ID          string                `fake:"{uuid}"      json:"_id"`
+	CertType    string                `json:"cert_type"`
+	Chain       []SSLCertificateChain `json:"chain"`
+	Fingerprint string                `json:"fingerprint"`
+	IsActive    FlexBool              `json:"is_active"`
+	IsValid     FlexBool              `json:"is_valid"`
+	Issuer      string                `json:"issuer"`
+	Serial      string                `json:"serial"`
+	Status      string                `json:"status"`
+	Subject     string                `json:"subject"`
+	ValidFrom   FlexInt               `json:"valid_from"`
+	ValidTo     FlexInt               `json:"valid_to"`
+
+	SiteName string `json:"-"`
+}
+
+// SSLCertificateChain represents a certificate in the chain (root, intermediate, etc.).
+type SSLCertificateChain struct {
+	CertType    string  `json:"cert_type"`
+	Fingerprint string  `json:"fingerprint"`
+	Issuer      string  `json:"issuer"`
+	Serial      string  `json:"serial"`
+	Subject     string  `json:"subject"`
+	ValidFrom   FlexInt `json:"valid_from"`
+	ValidTo     FlexInt `json:"valid_to"`
+}
+
+// GetSSLCertificate returns the active SSL certificate info for a single site.
+// Uses the legacy API endpoint: GET /api/s/{site}/stat/active.
+func (u *Unifi) GetSSLCertificate(site *Site) (*SSLCertificate, error) {
+	if site == nil || site.Name == "" {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Controller for SSL certificate, site %s", site.SiteName)
+
+	path := fmt.Sprintf(APISSLCertPath, site.Name)
+
+	var response struct {
+		Data []SSLCertificate `json:"data"`
+	}
+
+	if err := u.GetData(path, &response); err != nil {
+		return nil, fmt.Errorf("fetching SSL certificate for site %s: %w", site.SiteName, err)
+	}
+
+	if len(response.Data) == 0 {
+		return &SSLCertificate{SiteName: site.SiteName}, nil
+	}
+
+	response.Data[0].SiteName = site.SiteName
+
+	return &response.Data[0], nil
+}

--- a/ssl_cert.go
+++ b/ssl_cert.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetSSLCertificate returns SSL certificate information for a site.
+func (u *Unifi) GetSSLCertificate(_ *Site) (*SSLCertificate, error) {
+	return nil, nil
+}

--- a/ssl_cert.go
+++ b/ssl_cert.go
@@ -33,12 +33,18 @@ type SSLCertificateChain struct {
 
 // GetSSLCertificate returns the active SSL certificate info for a single site.
 // Uses the legacy API endpoint: GET /api/s/{site}/stat/active.
+// When the controller returns no certificate data, a zero-value SSLCertificate is returned
+// with only SiteName set. Callers can detect this case by checking cert.ID == "".
 func (u *Unifi) GetSSLCertificate(site *Site) (*SSLCertificate, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil || site.Name == "" {
 		return nil, ErrNoSiteProvided
 	}
 
-	u.DebugLog("Polling Controller for SSL certificate, site %s", site.SiteName)
+	u.DebugLog("Polling Controller for SSL certificate, site %s", site.Name)
 
 	path := fmt.Sprintf(APISSLCertPath, site.Name)
 
@@ -47,11 +53,17 @@ func (u *Unifi) GetSSLCertificate(site *Site) (*SSLCertificate, error) {
 	}
 
 	if err := u.GetData(path, &response); err != nil {
-		return nil, fmt.Errorf("fetching SSL certificate for site %s: %w", site.SiteName, err)
+		return nil, fmt.Errorf("fetching SSL certificate for site %s: %w", site.Name, err)
 	}
 
 	if len(response.Data) == 0 {
+		u.DebugLog("No SSL certificate found for site %s", site.Name)
+
 		return &SSLCertificate{SiteName: site.SiteName}, nil
+	}
+
+	if len(response.Data) > 1 {
+		u.DebugLog("SSL certificate response for site %s contained %d entries; using first", site.Name, len(response.Data))
 	}
 
 	response.Data[0].SiteName = site.SiteName

--- a/ssl_cert_test.go
+++ b/ssl_cert_test.go
@@ -1,0 +1,37 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestSSLCertificateStruct(t *testing.T) {
+	t.Parallel()
+
+	var c unifi.SSLCertificate
+
+	err := gofakeit.Struct(&c)
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ID)
+}
+
+func TestSSLCertificateChainStruct(t *testing.T) {
+	t.Parallel()
+
+	var chain unifi.SSLCertificateChain
+
+	err := gofakeit.Struct(&chain)
+	require.NoError(t, err)
+}
+
+func TestNetworkExtendedFields(t *testing.T) {
+	t.Parallel()
+
+	var n unifi.Network
+
+	err := gofakeit.Struct(&n)
+	require.NoError(t, err)
+}

--- a/switching.go
+++ b/switching.go
@@ -5,8 +5,16 @@ import "fmt"
 // GetLAGs returns link aggregation group configurations for a site.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetLAGs(site *IntegrationSite) ([]*LAG, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration API for LAG data, site %s", site.Name)
@@ -31,8 +39,16 @@ func (u *Unifi) GetLAGs(site *IntegrationSite) ([]*LAG, error) {
 // GetMCLAGDomains returns multi-chassis LAG domain configurations for a site.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetMCLAGDomains(site *IntegrationSite) ([]*MCLAGDomain, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration API for MCLAG domain data, site %s", site.Name)
@@ -57,8 +73,16 @@ func (u *Unifi) GetMCLAGDomains(site *IntegrationSite) ([]*MCLAGDomain, error) {
 // GetSwitchStacks returns switch stack configurations for a site.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetSwitchStacks(site *IntegrationSite) ([]*SwitchStack, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration API for switch stack data, site %s", site.Name)

--- a/switching.go
+++ b/switching.go
@@ -1,0 +1,16 @@
+package unifi
+
+// GetLAGs returns link aggregation group configurations for a site.
+func (u *Unifi) GetLAGs(_ *IntegrationSite) ([]*LAG, error) {
+	return nil, nil
+}
+
+// GetMCLAGDomains returns multi-chassis LAG domain configurations for a site.
+func (u *Unifi) GetMCLAGDomains(_ *IntegrationSite) ([]*MCLAGDomain, error) {
+	return nil, nil
+}
+
+// GetSwitchStacks returns switch stack configurations for a site.
+func (u *Unifi) GetSwitchStacks(_ *IntegrationSite) ([]*SwitchStack, error) {
+	return nil, nil
+}

--- a/switching.go
+++ b/switching.go
@@ -1,0 +1,81 @@
+package unifi
+
+import "fmt"
+
+// GetLAGs returns link aggregation group configurations for a site.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetLAGs(site *IntegrationSite) ([]*LAG, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration API for LAG data, site %s", site.Name)
+
+	path := fmt.Sprintf(APILAGsPath, site.ID)
+
+	items, err := getIntegrationList[LAG](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching LAGs for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*LAG, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}
+
+// GetMCLAGDomains returns multi-chassis LAG domain configurations for a site.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetMCLAGDomains(site *IntegrationSite) ([]*MCLAGDomain, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration API for MCLAG domain data, site %s", site.Name)
+
+	path := fmt.Sprintf(APIMCLAGDomainsPath, site.ID)
+
+	items, err := getIntegrationList[MCLAGDomain](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching MCLAG domains for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*MCLAGDomain, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}
+
+// GetSwitchStacks returns switch stack configurations for a site.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetSwitchStacks(site *IntegrationSite) ([]*SwitchStack, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration API for switch stack data, site %s", site.Name)
+
+	path := fmt.Sprintf(APISwitchStacksPath, site.ID)
+
+	items, err := getIntegrationList[SwitchStack](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching switch stacks for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*SwitchStack, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}

--- a/switching_test.go
+++ b/switching_test.go
@@ -1,0 +1,73 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestLAG(t *testing.T) {
+	t.Parallel()
+
+	var l unifi.LAG
+
+	require.NoError(t, gofakeit.Struct(&l))
+}
+
+func TestLAGMember(t *testing.T) {
+	t.Parallel()
+
+	var m unifi.LAGMember
+
+	require.NoError(t, gofakeit.Struct(&m))
+}
+
+func TestLAGMetadata(t *testing.T) {
+	t.Parallel()
+
+	var m unifi.LAGMetadata
+
+	require.NoError(t, gofakeit.Struct(&m))
+}
+
+func TestMCLAGDomain(t *testing.T) {
+	t.Parallel()
+
+	var d unifi.MCLAGDomain
+
+	require.NoError(t, gofakeit.Struct(&d))
+}
+
+func TestMCLAGPeer(t *testing.T) {
+	t.Parallel()
+
+	var p unifi.MCLAGPeer
+
+	require.NoError(t, gofakeit.Struct(&p))
+}
+
+func TestMCLAGMetadata(t *testing.T) {
+	t.Parallel()
+
+	var m unifi.MCLAGMetadata
+
+	require.NoError(t, gofakeit.Struct(&m))
+}
+
+func TestSwitchStack(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.SwitchStack
+
+	require.NoError(t, gofakeit.Struct(&s))
+}
+
+func TestSwitchStackMetadata(t *testing.T) {
+	t.Parallel()
+
+	var m unifi.SwitchStackMetadata
+
+	require.NoError(t, gofakeit.Struct(&m))
+}

--- a/traffic_matching_lists.go
+++ b/traffic_matching_lists.go
@@ -4,8 +4,16 @@ import "fmt"
 
 // GetTrafficMatchingLists returns traffic matching lists for a site.
 func (u *Unifi) GetTrafficMatchingLists(site *IntegrationSite) ([]*TrafficMatchingList, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for traffic matching lists, site %s", site.Name)

--- a/traffic_matching_lists.go
+++ b/traffic_matching_lists.go
@@ -1,0 +1,28 @@
+package unifi
+
+import "fmt"
+
+// GetTrafficMatchingLists returns traffic matching lists for a site.
+func (u *Unifi) GetTrafficMatchingLists(site *IntegrationSite) ([]*TrafficMatchingList, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for traffic matching lists, site %s", site.Name)
+
+	path := fmt.Sprintf(APITrafficMatchingListsPath, site.ID)
+
+	items, err := getIntegrationList[TrafficMatchingList](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching traffic matching lists for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*TrafficMatchingList, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}

--- a/traffic_matching_lists.go
+++ b/traffic_matching_lists.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetTrafficMatchingLists returns traffic matching lists for a site.
+func (u *Unifi) GetTrafficMatchingLists(_ *IntegrationSite) ([]*TrafficMatchingList, error) {
+	return nil, nil
+}

--- a/traffic_matching_lists_test.go
+++ b/traffic_matching_lists_test.go
@@ -1,0 +1,17 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestTrafficMatchingList(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.TrafficMatchingList
+
+	require.NoError(t, gofakeit.Struct(&s))
+}

--- a/types.go
+++ b/types.go
@@ -195,6 +195,37 @@ const (
 	APIMagicSiteToSiteVPNPath string = "/proxy/network/v2/api/site/%s/magicsitetositevpn/configs"
 	// APISysinfoPath returns controller system info and health (UniFi OS).
 	APISysinfoPath string = "/api/s/%s/stat/sysinfo"
+
+	// Integration/v1 API paths — require X-API-Key auth (APIKey in Config).
+	// Paths already include /proxy/network prefix and are not modified by path().
+	APIIntegrationSitesPath       string = "/proxy/network/integration/v1/sites"
+	APIIntegrationDevicesPath     string = "/proxy/network/integration/v1/sites/%s/devices"
+	APIIntegrationDeviceStatsPath string = "/proxy/network/integration/v1/sites/%s/devices/%s/statistics/latest"
+	APIWifiBroadcastsPath         string = "/proxy/network/integration/v1/sites/%s/wifi/broadcasts"
+	APIFirewallZonesPath          string = "/proxy/network/integration/v1/sites/%s/firewall/zones"
+	APIACLRulesPath               string = "/proxy/network/integration/v1/sites/%s/acl-rules"
+	APIIntegrationNetworksPath    string = "/proxy/network/integration/v1/sites/%s/networks"
+	APIIntegrationWANsPath        string = "/proxy/network/integration/v1/sites/%s/wans"
+	APIVPNServersPath             string = "/proxy/network/integration/v1/sites/%s/vpn/servers"
+	APISiteToSiteTunnelsPath      string = "/proxy/network/integration/v1/sites/%s/vpn/site-to-site-tunnels"
+	APILAGsPath                   string = "/proxy/network/integration/v1/sites/%s/switching/lags"
+	APIMCLAGDomainsPath           string = "/proxy/network/integration/v1/sites/%s/switching/mc-lag-domains"
+	APISwitchStacksPath           string = "/proxy/network/integration/v1/sites/%s/switching/switch-stacks"
+	APIDNSPoliciesPath            string = "/proxy/network/integration/v1/sites/%s/dns/policies"
+	APIRADIUSProfilesPath         string = "/proxy/network/integration/v1/sites/%s/radius/profiles"
+	APITrafficMatchingListsPath   string = "/proxy/network/integration/v1/sites/%s/traffic-matching-lists"
+	APIHotspotVouchersPath        string = "/proxy/network/integration/v1/sites/%s/hotspot/vouchers"
+	APIDPIApplicationsPath        string = "/proxy/network/integration/v1/dpi/applications"
+	APIDPICategoriesPath          string = "/proxy/network/integration/v1/dpi/categories"
+	APIPendingDevicesPath         string = "/proxy/network/integration/v1/pending-devices"
+	APIIntegrationInfoPath        string = "/proxy/network/integration/v1/info"
+	APICountriesPath              string = "/proxy/network/integration/v1/countries"
+
+	// Legacy gap API paths (Part A).
+	APIWANStatusPath   string = "/api/s/%s/stat/status"
+	APIUPSDevicesPath  string = "/api/s/%s/stat/ups-devices"
+	APIPortForwardPath string = "/api/s/%s/rest/portforward"
+	APISSLCertPath     string = "/api/s/%s/stat/active"
 )
 
 // path returns the correct api path based on the new variable.
@@ -250,6 +281,341 @@ type Config struct {
 	DebugLog  Logger
 	Timeout   time.Duration // how long to wait for replies, default: forever.
 	VerifySSL bool
+}
+
+// IntegrationSite holds site identity from GET /proxy/network/integration/v1/sites.
+// InternalReference matches the legacy Site.Name ("default") for cross-lookup.
+type IntegrationSite struct {
+	ID                string `json:"id"`
+	InternalReference string `json:"internalReference"`
+	Name              string `json:"name"`
+}
+
+// IntegrationInfo holds application version from GET /proxy/network/integration/v1/info.
+type IntegrationInfo struct {
+	ApplicationVersion string `json:"applicationVersion"`
+}
+
+// IntegrationDeviceRadioStats holds per-radio stats within IntegrationDeviceStats.
+type IntegrationDeviceRadioStats struct {
+	FrequencyGHz float64 `json:"frequencyGHz"`
+	TxRetriesPct float64 `json:"txRetriesPct"`
+}
+
+// IntegrationDeviceUplinkStats holds per-uplink stats within IntegrationDeviceStats.
+type IntegrationDeviceUplinkStats struct {
+	RxRateBps int64 `json:"rxRateBps"`
+	TxRateBps int64 `json:"txRateBps"`
+}
+
+// IntegrationDeviceStats holds device statistics from the Integration/v1 API.
+type IntegrationDeviceStats struct {
+	CPUUtilizationPct    float64                        `json:"cpuUtilizationPct"`
+	DeviceID             string                         `json:"deviceId"`
+	LastHeartbeatAt      string                         `json:"lastHeartbeatAt"`
+	LoadAverage15Min     float64                        `json:"loadAverage15Min"`
+	LoadAverage1Min      float64                        `json:"loadAverage1Min"`
+	LoadAverage5Min      float64                        `json:"loadAverage5Min"`
+	MemoryUtilizationPct float64                        `json:"memoryUtilizationPct"`
+	NextHeartbeatAt      string                         `json:"nextHeartbeatAt"`
+	Radios               []IntegrationDeviceRadioStats  `json:"radios"`
+	Uplinks              []IntegrationDeviceUplinkStats `json:"uplinks"`
+	UptimeSec            int64                          `json:"uptimeSec"`
+}
+
+// WifiBroadcastSecurityConfiguration holds security settings for a WiFi broadcast.
+type WifiBroadcastSecurityConfiguration struct {
+	PSK           string `json:"psk"`
+	RADIUSProfile string `json:"radiusProfile"`
+	Type          string `json:"type"` // WPA2, WPA3, open
+}
+
+// WifiBroadcast represents a WiFi SSID broadcast from the Integration/v1 API.
+type WifiBroadcast struct {
+	BroadcastingDeviceFilter []string                           `json:"broadcastingDeviceFilter"`
+	Enabled                  bool                               `json:"enabled"`
+	ID                       string                             `json:"id"`
+	Name                     string                             `json:"name"`
+	Network                  string                             `json:"network"`
+	SecurityConfiguration    WifiBroadcastSecurityConfiguration `json:"securityConfiguration"`
+
+	SiteName string `json:"-"`
+}
+
+// FirewallZoneMetadata holds metadata for a firewall zone.
+type FirewallZoneMetadata struct {
+	Origin string `json:"origin"` // system, user
+}
+
+// FirewallZone represents a firewall zone from the Integration/v1 API.
+// Zone IDs appear in FirewallPolicy source/destination fields.
+type FirewallZone struct {
+	ID         string               `json:"id"`
+	Metadata   FirewallZoneMetadata `json:"metadata"`
+	Name       string               `json:"name"`
+	NetworkIDs []string             `json:"networkIds"`
+
+	SiteName string `json:"-"`
+}
+
+// ACLRule represents a network access control rule from the Integration/v1 API.
+type ACLRule struct {
+	Action                string   `json:"action"` // ALLOW, BLOCK
+	Description           string   `json:"description"`
+	Enabled               bool     `json:"enabled"`
+	EnforcingDeviceFilter []string `json:"enforcingDeviceFilter"`
+	ID                    string   `json:"id"`
+	Index                 int      `json:"index"`
+	Name                  string   `json:"name"`
+	SourceFilter          string   `json:"sourceFilter"`
+
+	SiteName string `json:"-"`
+}
+
+// IntegrationNetwork represents a network from the Integration/v1 API.
+// Complements the legacy GetNetworks() which remains for backward compatibility.
+type IntegrationNetwork struct {
+	DHCPGuarding bool   `json:"dhcpGuarding"`
+	Enabled      bool   `json:"enabled"`
+	ID           string `json:"id"`
+	Management   string `json:"management"` // gateway, switch-managed, unmanaged
+	Name         string `json:"name"`
+	VlanID       int    `json:"vlanId"`
+
+	SiteName string `json:"-"`
+}
+
+// IntegrationWAN represents a WAN interface identifier from the Integration/v1 API.
+type IntegrationWAN struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+
+	SiteName string `json:"-"`
+}
+
+// VPNServerMetadata holds metadata for a VPN server.
+type VPNServerMetadata struct {
+	Origin string `json:"origin"`
+}
+
+// VPNServer represents a VPN server from the Integration/v1 API.
+type VPNServer struct {
+	Enabled  bool              `json:"enabled"`
+	ID       string            `json:"id"`
+	Metadata VPNServerMetadata `json:"metadata"`
+	Name     string            `json:"name"`
+	Type     string            `json:"type"` // L2TP, OpenVPN, WireGuard, UID
+
+	SiteName string `json:"-"`
+}
+
+// SiteToSiteTunnelMetadata holds metadata for a site-to-site tunnel.
+type SiteToSiteTunnelMetadata struct {
+	Origin string `json:"origin"`
+}
+
+// SiteToSiteTunnel represents a site-to-site VPN tunnel from the Integration/v1 API.
+type SiteToSiteTunnel struct {
+	ID       string                   `json:"id"`
+	Metadata SiteToSiteTunnelMetadata `json:"metadata"`
+	Name     string                   `json:"name"`
+	Type     string                   `json:"type"` // IPSec, OpenVPN, WireGuard
+
+	SiteName string `json:"-"`
+}
+
+// LAGMember represents a device port membership within a LAG.
+type LAGMember struct {
+	DeviceID    string `json:"deviceId"`
+	PortIndexes []int  `json:"portIndexes"`
+}
+
+// LAGMetadata holds metadata for a LAG.
+type LAGMetadata struct {
+	Origin string `json:"origin"`
+}
+
+// LAG represents a link aggregation group from the Integration/v1 API.
+type LAG struct {
+	ID       string      `json:"id"`
+	Members  []LAGMember `json:"members"`
+	Metadata LAGMetadata `json:"metadata"`
+	Type     string      `json:"type"` // local, global
+
+	SiteName string `json:"-"`
+}
+
+// MCLAGPeer represents a peer device in an MC-LAG domain.
+type MCLAGPeer struct {
+	DeviceID  string `json:"deviceId"`
+	LinkPorts []int  `json:"linkPorts"`
+	Role      string `json:"role"`
+}
+
+// MCLAGMetadata holds metadata for an MC-LAG domain.
+type MCLAGMetadata struct {
+	Origin string `json:"origin"`
+}
+
+// MCLAGDomain represents a multi-chassis LAG domain from the Integration/v1 API.
+type MCLAGDomain struct {
+	ID       string        `json:"id"`
+	LAGs     []string      `json:"lags"`
+	Metadata MCLAGMetadata `json:"metadata"`
+	Name     string        `json:"name"`
+	Peers    []MCLAGPeer   `json:"peers"`
+
+	SiteName string `json:"-"`
+}
+
+// SwitchStackMetadata holds metadata for a switch stack.
+type SwitchStackMetadata struct {
+	Origin string `json:"origin"`
+}
+
+// SwitchStack represents a switch stack from the Integration/v1 API.
+type SwitchStack struct {
+	ID       string              `json:"id"`
+	LAGs     []string            `json:"lags"`
+	Members  []string            `json:"members"` // device IDs
+	Metadata SwitchStackMetadata `json:"metadata"`
+	Name     string              `json:"name"`
+
+	SiteName string `json:"-"`
+}
+
+// DNSPolicy represents a DNS policy from the Integration/v1 API.
+type DNSPolicy struct {
+	Domain  string `json:"domain"`
+	Enabled bool   `json:"enabled"`
+	ID      string `json:"id"`
+	Type    string `json:"type"` // forward-domain, block, allow
+
+	SiteName string `json:"-"`
+}
+
+// RADIUSProfileMetadata holds metadata for a RADIUS profile.
+type RADIUSProfileMetadata struct {
+	Origin string `json:"origin"`
+}
+
+// RADIUSProfile represents a RADIUS authentication profile from the Integration/v1 API.
+type RADIUSProfile struct {
+	ID       string                `json:"id"`
+	Metadata RADIUSProfileMetadata `json:"metadata"`
+	Name     string                `json:"name"`
+
+	SiteName string `json:"-"`
+}
+
+// TrafficMatchingList represents a traffic matching list from the Integration/v1 API.
+// Used as references in firewall policy traffic filters.
+type TrafficMatchingList struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"` // IPv4, IPv6, port
+
+	SiteName string `json:"-"`
+}
+
+// HotspotVoucher represents a guest portal voucher from the Integration/v1 API.
+type HotspotVoucher struct {
+	ActivatedAt          string  `json:"activatedAt"`
+	AuthorizedGuestCount int     `json:"authorizedGuestCount"`
+	AuthorizedGuestLimit int     `json:"authorizedGuestLimit"`
+	Code                 string  `json:"code"`
+	DataUsageLimitMBytes float64 `json:"dataUsageLimitMBytes"`
+	ExpiresAt            string  `json:"expiresAt"`
+	ID                   string  `json:"id"`
+	Name                 string  `json:"name"`
+	TimeLimitMinutes     int     `json:"timeLimitMinutes"`
+
+	SiteName string `json:"-"`
+}
+
+// DPIApplication represents an entry in the DPI application catalogue.
+type DPIApplication struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// DPICategory represents an entry in the DPI category catalogue.
+type DPICategory struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// PendingDevice represents a device in the adoption queue.
+type PendingDevice struct {
+	FirmwareUpdatable bool     `json:"firmwareUpdatable"`
+	FirmwareVersion   string   `json:"firmwareVersion"`
+	Features          []string `json:"features"`
+	IPAddress         string   `json:"ipAddress"`
+	MACAddress        string   `json:"macAddress"`
+	Model             string   `json:"model"`
+	State             string   `json:"state"`
+	Supported         bool     `json:"supported"`
+}
+
+// Country represents a country entry for geo-based firewall policy filters.
+type Country struct {
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
+// WANStatusInterface represents a single WAN interface status entry.
+type WANStatusInterface struct {
+	Name         string `json:"name"`
+	NetworkGroup string `json:"network_group"` // WAN, WAN2
+	State        string `json:"state"`         // ACTIVE, BACKUP
+}
+
+// WANStatus represents WAN interface status from /api/s/{site}/stat/status.
+type WANStatus struct {
+	WANInterfaces []WANStatusInterface `json:"wan_interfaces"`
+
+	SiteName string `json:"-"`
+}
+
+// UPSDeviceSelector is a lightweight UPS/PDU device identity entry.
+type UPSDeviceSelector struct {
+	ImageURL string `json:"image_url"`
+	Label    string `json:"label"`
+	MAC      string `json:"mac"`
+	SiteID   string `json:"site_id"`
+}
+
+// PortForward represents a port forwarding rule from the UniFi controller.
+type PortForward struct {
+	DstPort  string   `json:"dst_port"`
+	Enabled  FlexBool `json:"enabled"`
+	Fwd      string   `json:"fwd"`
+	FwdPort  string   `json:"fwd_port"`
+	ID       string   `json:"_id"`
+	Name     string   `json:"name"`
+	Proto    string   `json:"proto"` // tcp, udp, tcp_udp
+	Src      string   `json:"src"`
+	SrcPort  FlexInt  `json:"src_port"`
+
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
+}
+
+// SSLCertificateChain represents one certificate in an SSL chain.
+type SSLCertificateChain struct {
+	Fingerprint string `json:"fingerprint"`
+	Issuer      string `json:"issuer"`
+	Subject     string `json:"subject"`
+	ValidFrom   string `json:"valid_from"`
+	ValidTo     string `json:"valid_to"`
+}
+
+// SSLCertificate represents SSL certificate information from the UniFi controller.
+type SSLCertificate struct {
+	Chain  []SSLCertificateChain `json:"chain"`
+	Status string                `json:"status"`
+
+	SiteName string `json:"-"`
 }
 
 type UnifiClient interface { //nolint: revive
@@ -355,6 +721,59 @@ type UnifiClient interface { //nolint: revive
 	GetMagicSiteToSiteVPN(sites []*Site) ([]*MagicSiteToSiteVPN, error)
 	// GetMagicSiteToSiteVPNSite returns Site Magic site-to-site VPN mesh configurations for a single Site.
 	GetMagicSiteToSiteVPNSite(site *Site) ([]*MagicSiteToSiteVPN, error)
+	// GetIntegrationSites returns all sites from the Integration/v1 API.
+	// Requires Config.APIKey; join on InternalReference == Site.Name to get UUID.
+	GetIntegrationSites() ([]*IntegrationSite, error)
+	// GetIntegrationInfo returns application version info from the Integration/v1 API.
+	GetIntegrationInfo() (*IntegrationInfo, error)
+	// GetIntegrationDeviceStats returns statistics for a single device from Integration/v1 API.
+	GetIntegrationDeviceStats(site *IntegrationSite, deviceID string) (*IntegrationDeviceStats, error)
+	// GetAllIntegrationDeviceStats returns statistics for all devices in a site.
+	GetAllIntegrationDeviceStats(site *IntegrationSite) ([]*IntegrationDeviceStats, error)
+	// GetWifiBroadcasts returns WiFi broadcast (SSID) configurations for a site.
+	GetWifiBroadcasts(site *IntegrationSite) ([]*WifiBroadcast, error)
+	// GetFirewallZones returns firewall zones for a site. Zone IDs appear in firewall policies.
+	GetFirewallZones(site *IntegrationSite) ([]*FirewallZone, error)
+	// GetACLRules returns access control rules for a site.
+	GetACLRules(site *IntegrationSite) ([]*ACLRule, error)
+	// GetIntegrationNetworks returns networks for a site from the Integration/v1 API.
+	GetIntegrationNetworks(site *IntegrationSite) ([]*IntegrationNetwork, error)
+	// GetIntegrationWANs returns WAN interface identifiers for a site.
+	GetIntegrationWANs(site *IntegrationSite) ([]*IntegrationWAN, error)
+	// GetVPNServers returns VPN server configurations for a site.
+	GetVPNServers(site *IntegrationSite) ([]*VPNServer, error)
+	// GetSiteToSiteTunnels returns site-to-site VPN tunnel configurations for a site.
+	GetSiteToSiteTunnels(site *IntegrationSite) ([]*SiteToSiteTunnel, error)
+	// GetLAGs returns link aggregation group configurations for a site.
+	GetLAGs(site *IntegrationSite) ([]*LAG, error)
+	// GetMCLAGDomains returns multi-chassis LAG domain configurations for a site.
+	GetMCLAGDomains(site *IntegrationSite) ([]*MCLAGDomain, error)
+	// GetSwitchStacks returns switch stack configurations for a site.
+	GetSwitchStacks(site *IntegrationSite) ([]*SwitchStack, error)
+	// GetDNSPolicies returns DNS policies for a site.
+	GetDNSPolicies(site *IntegrationSite) ([]*DNSPolicy, error)
+	// GetRADIUSProfiles returns RADIUS authentication profiles for a site.
+	GetRADIUSProfiles(site *IntegrationSite) ([]*RADIUSProfile, error)
+	// GetTrafficMatchingLists returns traffic matching lists for a site.
+	GetTrafficMatchingLists(site *IntegrationSite) ([]*TrafficMatchingList, error)
+	// GetHotspotVouchers returns guest portal vouchers for a site.
+	GetHotspotVouchers(site *IntegrationSite) ([]*HotspotVoucher, error)
+	// GetDPIApplications returns the DPI application reference catalogue (global, no site).
+	GetDPIApplications() ([]*DPIApplication, error)
+	// GetDPICategories returns the DPI category reference catalogue (global, no site).
+	GetDPICategories() ([]*DPICategory, error)
+	// GetPendingDevices returns devices waiting to be adopted (global, no site).
+	GetPendingDevices() ([]*PendingDevice, error)
+	// GetCountries returns the list of countries for geo-based firewall filters (global, no site).
+	GetCountries() ([]*Country, error)
+	// GetWANStatus returns WAN interface status (ACTIVE/BACKUP) for a site.
+	GetWANStatus(site *Site) (*WANStatus, error)
+	// GetUPSDeviceList returns UPS/PDU device selectors for a site.
+	GetUPSDeviceList(site *Site) ([]*UPSDeviceSelector, error)
+	// GetPortForwards returns port forwarding rules for a site.
+	GetPortForwards(site *Site) ([]*PortForward, error)
+	// GetSSLCertificate returns SSL certificate information for a site.
+	GetSSLCertificate(site *Site) (*SSLCertificate, error)
 }
 
 // Unifi is what you get in return for providing a password! Unifi represents

--- a/types.go
+++ b/types.go
@@ -195,6 +195,14 @@ const (
 	APIMagicSiteToSiteVPNPath string = "/proxy/network/v2/api/site/%s/magicsitetositevpn/configs"
 	// APISysinfoPath returns controller system info and health (UniFi OS).
 	APISysinfoPath string = "/api/s/%s/stat/sysinfo"
+	// APIWANStatusPath returns WAN interface status from the legacy controller API.
+	APIWANStatusPath string = "/api/s/%s/stat/status"
+	// APIUPSDevicesPath returns UPS device selector list from the legacy controller API.
+	APIUPSDevicesPath string = "/api/s/%s/stat/ups-devices"
+	// APIPortForwardPath returns port forwarding rules from the legacy controller API.
+	APIPortForwardPath string = "/api/s/%s/rest/portforward"
+	// APISSLCertPath returns active SSL certificate info from the legacy controller API.
+	APISSLCertPath string = "/api/s/%s/stat/active"
 )
 
 // path returns the correct api path based on the new variable.
@@ -355,6 +363,14 @@ type UnifiClient interface { //nolint: revive
 	GetMagicSiteToSiteVPN(sites []*Site) ([]*MagicSiteToSiteVPN, error)
 	// GetMagicSiteToSiteVPNSite returns Site Magic site-to-site VPN mesh configurations for a single Site.
 	GetMagicSiteToSiteVPNSite(site *Site) ([]*MagicSiteToSiteVPN, error)
+	// GetWANStatus returns the WAN interface status for a single site.
+	GetWANStatus(site *Site) (*WANStatus, error)
+	// GetUPSDeviceList returns the list of UPS device selectors for a single site.
+	GetUPSDeviceList(site *Site) ([]*UPSDeviceSelector, error)
+	// GetPortForwards returns port forwarding rules for a single site.
+	GetPortForwards(site *Site) ([]*PortForward, error)
+	// GetSSLCertificate returns the active SSL certificate info for a single site.
+	GetSSLCertificate(site *Site) (*SSLCertificate, error)
 }
 
 // Unifi is what you get in return for providing a password! Unifi represents

--- a/types.go
+++ b/types.go
@@ -298,29 +298,29 @@ type IntegrationInfo struct {
 
 // IntegrationDeviceRadioStats holds per-radio stats within IntegrationDeviceStats.
 type IntegrationDeviceRadioStats struct {
-	FrequencyGHz float64 `json:"frequencyGHz"`
-	TxRetriesPct float64 `json:"txRetriesPct"`
+	FrequencyGHz FlexInt `json:"frequencyGHz"` // fractional GHz (e.g. 2.4, 5.0); use .Val, not .Int()
+	TxRetriesPct FlexInt `json:"txRetriesPct"`
 }
 
 // IntegrationDeviceUplinkStats holds per-uplink stats within IntegrationDeviceStats.
 type IntegrationDeviceUplinkStats struct {
-	RxRateBps int64 `json:"rxRateBps"`
-	TxRateBps int64 `json:"txRateBps"`
+	RxRateBps FlexInt `json:"rxRateBps"`
+	TxRateBps FlexInt `json:"txRateBps"`
 }
 
 // IntegrationDeviceStats holds device statistics from the Integration/v1 API.
 type IntegrationDeviceStats struct {
-	CPUUtilizationPct    float64                        `json:"cpuUtilizationPct"`
+	CPUUtilizationPct    FlexInt                        `json:"cpuUtilizationPct"`
 	DeviceID             string                         `json:"deviceId"`
 	LastHeartbeatAt      string                         `json:"lastHeartbeatAt"`
-	LoadAverage15Min     float64                        `json:"loadAverage15Min"`
-	LoadAverage1Min      float64                        `json:"loadAverage1Min"`
-	LoadAverage5Min      float64                        `json:"loadAverage5Min"`
-	MemoryUtilizationPct float64                        `json:"memoryUtilizationPct"`
+	LoadAverage15Min     FlexInt                        `json:"loadAverage15Min"` // fractional Unix load average; use .Val, not .Int()
+	LoadAverage1Min      FlexInt                        `json:"loadAverage1Min"`  // fractional Unix load average; use .Val, not .Int()
+	LoadAverage5Min      FlexInt                        `json:"loadAverage5Min"`  // fractional Unix load average; use .Val, not .Int()
+	MemoryUtilizationPct FlexInt                        `json:"memoryUtilizationPct"`
 	NextHeartbeatAt      string                         `json:"nextHeartbeatAt"`
 	Radios               []IntegrationDeviceRadioStats  `json:"radios"`
 	Uplinks              []IntegrationDeviceUplinkStats `json:"uplinks"`
-	UptimeSec            int64                          `json:"uptimeSec"`
+	UptimeSec            FlexInt                        `json:"uptimeSec"`
 }
 
 // WifiBroadcastSecurityConfiguration holds security settings for a WiFi broadcast.
@@ -365,7 +365,7 @@ type ACLRule struct {
 	Enabled               bool     `json:"enabled"`
 	EnforcingDeviceFilter []string `json:"enforcingDeviceFilter"`
 	ID                    string   `json:"id"`
-	Index                 int      `json:"index"`
+	Index                 FlexInt  `json:"index"`
 	Name                  string   `json:"name"`
 	SourceFilter          string   `json:"sourceFilter"`
 
@@ -375,12 +375,12 @@ type ACLRule struct {
 // IntegrationNetwork represents a network from the Integration/v1 API.
 // Complements the legacy GetNetworks() which remains for backward compatibility.
 type IntegrationNetwork struct {
-	DHCPGuarding bool   `json:"dhcpGuarding"`
-	Enabled      bool   `json:"enabled"`
-	ID           string `json:"id"`
-	Management   string `json:"management"` // gateway, switch-managed, unmanaged
-	Name         string `json:"name"`
-	VlanID       int    `json:"vlanId"`
+	DHCPGuarding bool    `json:"dhcpGuarding"`
+	Enabled      bool    `json:"enabled"`
+	ID           string  `json:"id"`
+	Management   string  `json:"management"` // gateway, switch-managed, unmanaged
+	Name         string  `json:"name"`
+	VlanID       FlexInt `json:"vlanId"`
 
 	SiteName string `json:"-"`
 }
@@ -521,28 +521,30 @@ type TrafficMatchingList struct {
 // HotspotVoucher represents a guest portal voucher from the Integration/v1 API.
 type HotspotVoucher struct {
 	ActivatedAt          string  `json:"activatedAt"`
-	AuthorizedGuestCount int     `json:"authorizedGuestCount"`
-	AuthorizedGuestLimit int     `json:"authorizedGuestLimit"`
+	AuthorizedGuestCount FlexInt `json:"authorizedGuestCount"`
+	AuthorizedGuestLimit FlexInt `json:"authorizedGuestLimit"`
 	Code                 string  `json:"code"`
-	DataUsageLimitMBytes float64 `json:"dataUsageLimitMBytes"`
+	DataUsageLimitMBytes FlexInt `json:"dataUsageLimitMBytes"` // 0 means no data cap
 	ExpiresAt            string  `json:"expiresAt"`
 	ID                   string  `json:"id"`
 	Name                 string  `json:"name"`
-	TimeLimitMinutes     int     `json:"timeLimitMinutes"`
+	TimeLimitMinutes     FlexInt `json:"timeLimitMinutes"` // 0 means no time limit
 
 	SiteName string `json:"-"`
 }
 
 // DPIApplication represents an entry in the DPI application catalogue.
+// Use ID.Int() as the app key when calling DPIMap.GetApp.
 type DPIApplication struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID   FlexInt `json:"id"`
+	Name string  `json:"name"`
 }
 
 // DPICategory represents an entry in the DPI category catalogue.
+// Use ID.Int() as the cat key when calling DPIMap.Get or DPIMap.GetApp.
 type DPICategory struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID   FlexInt `json:"id"`
+	Name string  `json:"name"`
 }
 
 // PendingDevice represents a device in the adoption queue.
@@ -562,7 +564,6 @@ type Country struct {
 	Code string `json:"code"`
 	Name string `json:"name"`
 }
-
 
 type UnifiClient interface { //nolint: revive
 	// GetAlarms returns Alarms for a list of Sites.

--- a/unifi.go
+++ b/unifi.go
@@ -27,13 +27,16 @@ import (
 )
 
 var (
-	ErrAuthenticationFailed = fmt.Errorf("authentication failed")
-	ErrInvalidStatusCode    = fmt.Errorf("invalid status code from server")
-	ErrNoParams             = fmt.Errorf("requested PUT with no parameters")
-	ErrInvalidSignature     = fmt.Errorf("certificate signature does not match")
-	ErrNilUnifi             = fmt.Errorf("unifi client is nil")
-	ErrTooManyRequests      = fmt.Errorf("429 too many requests")
-	ErrAPIKeyRequired       = errors.New("integration/v1 API requires Config.APIKey to be set")
+	ErrAuthenticationFailed = errors.New("authentication failed")
+	ErrInvalidStatusCode    = errors.New("invalid status code from server")
+	ErrNoParams             = errors.New("requested PUT with no parameters")
+	ErrInvalidSignature     = errors.New("certificate signature does not match")
+	ErrNilUnifi             = errors.New("unifi client is nil")
+	ErrTooManyRequests      = errors.New("429 too many requests")
+
+	// Integration/v1 API sentinels.
+	ErrAPIKeyRequired    = errors.New("integration/v1 API requires Config.APIKey to be set")
+	ErrIncompleteResults = errors.New("integration/v1 API item count did not match server-reported totalCount")
 )
 
 // RateLimitError is returned when the controller responds with 429 Too Many Requests.

--- a/unifi.go
+++ b/unifi.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,6 +33,7 @@ var (
 	ErrInvalidSignature     = fmt.Errorf("certificate signature does not match")
 	ErrNilUnifi             = fmt.Errorf("unifi client is nil")
 	ErrTooManyRequests      = fmt.Errorf("429 too many requests")
+	ErrAPIKeyRequired       = errors.New("integration/v1 API requires Config.APIKey to be set")
 )
 
 // RateLimitError is returned when the controller responds with 429 Too Many Requests.

--- a/ups_device_selector.go
+++ b/ups_device_selector.go
@@ -10,16 +10,23 @@ type UPSDeviceSelector struct {
 	Label  string `fake:"{productname}" json:"label"`
 	MAC    string `fake:"{macaddress}"  json:"mac"`
 	SiteID string `fake:"{uuid}"        json:"site_id"`
+
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // GetUPSDeviceList returns the list of UPS device selectors for a single site.
 // Uses the legacy API endpoint: GET /api/s/{site}/stat/ups-devices.
 func (u *Unifi) GetUPSDeviceList(site *Site) ([]*UPSDeviceSelector, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil || site.Name == "" {
 		return nil, ErrNoSiteProvided
 	}
 
-	u.DebugLog("Polling Controller for UPS device list, site %s", site.SiteName)
+	u.DebugLog("Polling Controller for UPS device list, site %s", site.Name)
 
 	path := fmt.Sprintf(APIUPSDevicesPath, site.Name)
 
@@ -28,12 +35,14 @@ func (u *Unifi) GetUPSDeviceList(site *Site) ([]*UPSDeviceSelector, error) {
 	}
 
 	if err := u.GetData(path, &response); err != nil {
-		return nil, fmt.Errorf("fetching UPS device list for site %s: %w", site.SiteName, err)
+		return nil, fmt.Errorf("fetching UPS device list for site %s: %w", site.Name, err)
 	}
 
 	result := make([]*UPSDeviceSelector, len(response.Data))
 
 	for i := range response.Data {
+		response.Data[i].SiteName = site.SiteName
+		response.Data[i].SourceName = u.URL
 		result[i] = &response.Data[i]
 	}
 

--- a/ups_device_selector.go
+++ b/ups_device_selector.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetUPSDeviceList returns UPS/PDU device selectors for a site.
+func (u *Unifi) GetUPSDeviceList(_ *Site) ([]*UPSDeviceSelector, error) {
+	return nil, nil
+}

--- a/ups_device_selector.go
+++ b/ups_device_selector.go
@@ -1,0 +1,41 @@
+package unifi
+
+import "fmt"
+
+// UPSDeviceSelector represents a UPS device entry from /api/s/{site}/stat/ups-devices.
+// This is a lightweight selector format distinct from the full device data in /stat/device.
+type UPSDeviceSelector struct {
+	ID     string `fake:"{uuid}"        json:"_id"`
+	Image  string `fake:"{imageurl}"    json:"image"`
+	Label  string `fake:"{productname}" json:"label"`
+	MAC    string `fake:"{macaddress}"  json:"mac"`
+	SiteID string `fake:"{uuid}"        json:"site_id"`
+}
+
+// GetUPSDeviceList returns the list of UPS device selectors for a single site.
+// Uses the legacy API endpoint: GET /api/s/{site}/stat/ups-devices.
+func (u *Unifi) GetUPSDeviceList(site *Site) ([]*UPSDeviceSelector, error) {
+	if site == nil || site.Name == "" {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Controller for UPS device list, site %s", site.SiteName)
+
+	path := fmt.Sprintf(APIUPSDevicesPath, site.Name)
+
+	var response struct {
+		Data []UPSDeviceSelector `json:"data"`
+	}
+
+	if err := u.GetData(path, &response); err != nil {
+		return nil, fmt.Errorf("fetching UPS device list for site %s: %w", site.SiteName, err)
+	}
+
+	result := make([]*UPSDeviceSelector, len(response.Data))
+
+	for i := range response.Data {
+		result[i] = &response.Data[i]
+	}
+
+	return result, nil
+}

--- a/ups_device_selector_test.go
+++ b/ups_device_selector_test.go
@@ -1,0 +1,20 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestUPSDeviceSelectorStruct(t *testing.T) {
+	t.Parallel()
+
+	var d unifi.UPSDeviceSelector
+
+	err := gofakeit.Struct(&d)
+	require.NoError(t, err)
+	require.NotEmpty(t, d.ID)
+	require.NotEmpty(t, d.MAC)
+}

--- a/vpn_servers.go
+++ b/vpn_servers.go
@@ -1,11 +1,55 @@
 package unifi
 
-// GetVPNServers returns VPN server configurations for a site.
-func (u *Unifi) GetVPNServers(_ *IntegrationSite) ([]*VPNServer, error) {
-	return nil, nil
+import "fmt"
+
+// GetVPNServers returns VPN server configurations for a site from the Integration/v1 API.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetVPNServers(site *IntegrationSite) ([]*VPNServer, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for VPN servers, site %s", site.Name)
+
+	path := fmt.Sprintf(APIVPNServersPath, site.ID)
+
+	items, err := getIntegrationList[VPNServer](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching VPN servers for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*VPNServer, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }
 
-// GetSiteToSiteTunnels returns site-to-site VPN tunnel configurations for a site.
-func (u *Unifi) GetSiteToSiteTunnels(_ *IntegrationSite) ([]*SiteToSiteTunnel, error) {
-	return nil, nil
+// GetSiteToSiteTunnels returns site-to-site VPN tunnel configurations for a site from the Integration/v1 API.
+// Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
+func (u *Unifi) GetSiteToSiteTunnels(site *IntegrationSite) ([]*SiteToSiteTunnel, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for site-to-site tunnels, site %s", site.Name)
+
+	path := fmt.Sprintf(APISiteToSiteTunnelsPath, site.ID)
+
+	items, err := getIntegrationList[SiteToSiteTunnel](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching site-to-site tunnels for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*SiteToSiteTunnel, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/vpn_servers.go
+++ b/vpn_servers.go
@@ -1,0 +1,11 @@
+package unifi
+
+// GetVPNServers returns VPN server configurations for a site.
+func (u *Unifi) GetVPNServers(_ *IntegrationSite) ([]*VPNServer, error) {
+	return nil, nil
+}
+
+// GetSiteToSiteTunnels returns site-to-site VPN tunnel configurations for a site.
+func (u *Unifi) GetSiteToSiteTunnels(_ *IntegrationSite) ([]*SiteToSiteTunnel, error) {
+	return nil, nil
+}

--- a/vpn_servers.go
+++ b/vpn_servers.go
@@ -5,8 +5,16 @@ import "fmt"
 // GetVPNServers returns VPN server configurations for a site from the Integration/v1 API.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetVPNServers(site *IntegrationSite) ([]*VPNServer, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for VPN servers, site %s", site.Name)
@@ -31,8 +39,16 @@ func (u *Unifi) GetVPNServers(site *IntegrationSite) ([]*VPNServer, error) {
 // GetSiteToSiteTunnels returns site-to-site VPN tunnel configurations for a site from the Integration/v1 API.
 // Requires Config.APIKey; returns ErrAPIKeyRequired when no key is configured.
 func (u *Unifi) GetSiteToSiteTunnels(site *IntegrationSite) ([]*SiteToSiteTunnel, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for site-to-site tunnels, site %s", site.Name)

--- a/vpn_servers_test.go
+++ b/vpn_servers_test.go
@@ -1,0 +1,49 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestVPNServer(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.VPNServer
+
+	err := gofakeit.Struct(&s)
+	require.NoError(t, err)
+	require.NotEmpty(t, s.ID)
+	require.NotEmpty(t, s.Name)
+}
+
+func TestVPNServerMetadata(t *testing.T) {
+	t.Parallel()
+
+	var m unifi.VPNServerMetadata
+
+	err := gofakeit.Struct(&m)
+	require.NoError(t, err)
+}
+
+func TestSiteToSiteTunnel(t *testing.T) {
+	t.Parallel()
+
+	var tun unifi.SiteToSiteTunnel
+
+	err := gofakeit.Struct(&tun)
+	require.NoError(t, err)
+	require.NotEmpty(t, tun.ID)
+	require.NotEmpty(t, tun.Name)
+}
+
+func TestSiteToSiteTunnelMetadata(t *testing.T) {
+	t.Parallel()
+
+	var m unifi.SiteToSiteTunnelMetadata
+
+	err := gofakeit.Struct(&m)
+	require.NoError(t, err)
+}

--- a/wan_status.go
+++ b/wan_status.go
@@ -1,0 +1,45 @@
+package unifi
+
+import "fmt"
+
+// WANStatus represents the WAN interface status from /api/s/{site}/stat/status.
+type WANStatus struct {
+	WANInterfaces []WANStatusInterface `json:"wan_interfaces"`
+
+	SiteName string `json:"-"`
+}
+
+// WANStatusInterface represents a single WAN interface in the status response.
+type WANStatusInterface struct {
+	Name            string `fake:"{lexify:wan?}"                               json:"name"`
+	State           string `fake:"{randomstring:[ACTIVE,BACKUP,DISCONNECTED]}" json:"state"`
+	WANNetworkgroup string `fake:"{randomstring:[WAN,WAN2]}"                   json:"wan_networkgroup"`
+}
+
+// GetWANStatus returns the WAN interface status for a single site.
+// Uses the legacy API endpoint: GET /api/s/{site}/stat/status.
+func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
+	if site == nil || site.Name == "" {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Controller for WAN status, site %s", site.SiteName)
+
+	path := fmt.Sprintf(APIWANStatusPath, site.Name)
+
+	var response struct {
+		Data []WANStatus `json:"data"`
+	}
+
+	if err := u.GetData(path, &response); err != nil {
+		return nil, fmt.Errorf("fetching WAN status for site %s: %w", site.SiteName, err)
+	}
+
+	if len(response.Data) == 0 {
+		return &WANStatus{SiteName: site.SiteName}, nil
+	}
+
+	response.Data[0].SiteName = site.SiteName
+
+	return &response.Data[0], nil
+}

--- a/wan_status.go
+++ b/wan_status.go
@@ -18,12 +18,18 @@ type WANStatusInterface struct {
 
 // GetWANStatus returns the WAN interface status for a single site.
 // Uses the legacy API endpoint: GET /api/s/{site}/stat/status.
+// When no WAN data is returned (e.g. site has no gateway), a zero-value WANStatus with an
+// empty WANInterfaces slice is returned. Callers can detect this by checking len(status.WANInterfaces) == 0.
 func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil || site.Name == "" {
 		return nil, ErrNoSiteProvided
 	}
 
-	u.DebugLog("Polling Controller for WAN status, site %s", site.SiteName)
+	u.DebugLog("Polling Controller for WAN status, site %s", site.Name)
 
 	path := fmt.Sprintf(APIWANStatusPath, site.Name)
 
@@ -32,11 +38,17 @@ func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
 	}
 
 	if err := u.GetData(path, &response); err != nil {
-		return nil, fmt.Errorf("fetching WAN status for site %s: %w", site.SiteName, err)
+		return nil, fmt.Errorf("fetching WAN status for site %s: %w", site.Name, err)
 	}
 
 	if len(response.Data) == 0 {
+		u.DebugLog("No WAN status found for site %s", site.Name)
+
 		return &WANStatus{SiteName: site.SiteName}, nil
+	}
+
+	if len(response.Data) > 1 {
+		u.DebugLog("WAN status response for site %s contained %d entries; using first", site.Name, len(response.Data))
 	}
 
 	response.Data[0].SiteName = site.SiteName

--- a/wan_status.go
+++ b/wan_status.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetWANStatus returns WAN interface status (ACTIVE/BACKUP) for a site.
+func (u *Unifi) GetWANStatus(_ *Site) (*WANStatus, error) {
+	return nil, nil
+}

--- a/wan_status_test.go
+++ b/wan_status_test.go
@@ -1,0 +1,28 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestWANStatusStruct(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.WANStatus
+
+	err := gofakeit.Struct(&s)
+	require.NoError(t, err)
+}
+
+func TestWANStatusInterfaceStruct(t *testing.T) {
+	t.Parallel()
+
+	var iface unifi.WANStatusInterface
+
+	err := gofakeit.Struct(&iface)
+	require.NoError(t, err)
+	require.NotEmpty(t, iface.Name)
+}

--- a/wifi_broadcasts.go
+++ b/wifi_broadcasts.go
@@ -4,8 +4,16 @@ import "fmt"
 
 // GetWifiBroadcasts returns WiFi broadcast (SSID) configurations for a site.
 func (u *Unifi) GetWifiBroadcasts(site *IntegrationSite) ([]*WifiBroadcast, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
 	if site == nil {
 		return nil, ErrNoSiteProvided
+	}
+
+	if site.ID == "" {
+		return nil, fmt.Errorf("site %q has an empty ID; cannot construct Integration/v1 API path", site.Name)
 	}
 
 	u.DebugLog("Polling Integration/v1 for WiFi broadcasts, site %s", site.Name)

--- a/wifi_broadcasts.go
+++ b/wifi_broadcasts.go
@@ -1,6 +1,28 @@
 package unifi
 
+import "fmt"
+
 // GetWifiBroadcasts returns WiFi broadcast (SSID) configurations for a site.
-func (u *Unifi) GetWifiBroadcasts(_ *IntegrationSite) ([]*WifiBroadcast, error) {
-	return nil, nil
+func (u *Unifi) GetWifiBroadcasts(site *IntegrationSite) ([]*WifiBroadcast, error) {
+	if site == nil {
+		return nil, ErrNoSiteProvided
+	}
+
+	u.DebugLog("Polling Integration/v1 for WiFi broadcasts, site %s", site.Name)
+
+	path := fmt.Sprintf(APIWifiBroadcastsPath, site.ID)
+
+	items, err := getIntegrationList[WifiBroadcast](u, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetching wifi broadcasts for site %s: %w", site.Name, err)
+	}
+
+	result := make([]*WifiBroadcast, len(items))
+
+	for i := range items {
+		items[i].SiteName = site.Name
+		result[i] = &items[i]
+	}
+
+	return result, nil
 }

--- a/wifi_broadcasts.go
+++ b/wifi_broadcasts.go
@@ -1,0 +1,6 @@
+package unifi
+
+// GetWifiBroadcasts returns WiFi broadcast (SSID) configurations for a site.
+func (u *Unifi) GetWifiBroadcasts(_ *IntegrationSite) ([]*WifiBroadcast, error) {
+	return nil, nil
+}

--- a/wifi_broadcasts_test.go
+++ b/wifi_broadcasts_test.go
@@ -1,0 +1,25 @@
+package unifi_test
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v5"
+)
+
+func TestWifiBroadcast(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.WifiBroadcast
+
+	require.NoError(t, gofakeit.Struct(&s))
+}
+
+func TestWifiBroadcastSecurityConfiguration(t *testing.T) {
+	t.Parallel()
+
+	var s unifi.WifiBroadcastSecurityConfiguration
+
+	require.NoError(t, gofakeit.Struct(&s))
+}


### PR DESCRIPTION
## Summary

- Introduces `getIntegrationList[T any]`, a generic offset-based pagination helper for Integration/v1 list endpoints, with drift detection, per-page protocol validation, and consistent `ErrorLog` coverage on all hard-error paths
- Migrates all eight package-level error sentinels from `fmt.Errorf` to `errors.New` for correct `errors.Is` identity semantics; groups the two new Integration/v1 sentinels (`ErrAPIKeyRequired`, `ErrIncompleteResults`) with a comment separator
- Wires the pagination helper into existing Integration/v1 getters (hotspot vouchers, traffic matching lists, device enumeration) and adds nil/empty-ID guards with per-site APIKey pre-checks where missing
- Adds `GetAllIntegrationDeviceStats` to fetch stats for every device in a site in one call
- Full getter coverage across: sites, device stats, WiFi broadcasts, firewall zones, ACL rules, networks, WANs, VPN servers, switching topology (LAGs, MCLAG domains, stacks), DNS policies, RADIUS profiles, traffic matching lists, hotspot vouchers, WAN status, UPS device list, SSL certificate

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass (unifi, main, mocks packages)
- [x] `var _ UnifiClient = &Unifi{}` compile-time assertion confirms all new methods satisfy the interface
- [x] Mock implements every new method (`mocks/mock_client.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)