### PR TITLE
fix: correct UCI SystemStats JSON tag (system_stats → system-stats)

### DIFF
--- a/uci.go
+++ b/uci.go
@@ -102,7 +102,7 @@ type UCI struct {
 	SysErrorCaps             FlexInt         `json:"sys_error_caps"`
 	SysStats                 *SysStats       `json:"sys_stats"`
 	SyslogKey                string          `json:"syslog_key"`
-	SystemStats              *SystemStats    `json:"system_stats"`
+	SystemStats              *SystemStats    `json:"system-stats"`
 	TwoPhaseAdopt            FlexBool        `json:"two_phase_adopt"`
 	TxBytes                  FlexInt         `json:"tx_bytes"`
 	Type                     string          `fake:"{lexify:uci}"                json:"type"`

--- a/uci_test.go
+++ b/uci_test.go
@@ -1,10 +1,12 @@
 package unifi_test
 
 import (
+	"encoding/json"
+	"testing"
+
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
 	"github.com/unpoller/unifi/v5"
-	"testing"
 )
 
 func TestUCI(test *testing.T) {
@@ -12,4 +14,20 @@ func TestUCI(test *testing.T) {
 	err := gofakeit.Struct(&uci)
 	require.NoError(test, err)
 	require.NotEmpty(test, uci.Name)
+}
+
+// TestUCISystemStatsUnmarshal verifies that the system-stats field (hyphen, as
+// returned by the UniFi controller API) correctly unmarshals into SystemStats.
+func TestUCISystemStatsUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"sys_stats":    {"loadavg_1": "8.21", "loadavg_5": "8.18", "loadavg_15": "5.44", "mem_buffer": 2572288, "mem_total": 258965504, "mem_used": 231374848},
+		"system-stats": {"cpu": "15.8", "mem": "89.3", "uptime": "711050"}
+	}`)
+
+	var uci unifi.UCI
+	require.NoError(t, json.Unmarshal(data, &uci))
+	require.NotNil(t, uci.SysStats, "SysStats should not be nil")
+	require.NotNil(t, uci.SystemStats, "SystemStats should not be nil (check JSON tag: system-stats not system_stats)")
+	require.Equal(t, "15.8", uci.SystemStats.CPU.String())
+	require.Equal(t, "89.3", uci.SystemStats.Mem.String())
 }


### PR DESCRIPTION
## Summary

The `UCI` struct has a typo in the JSON tag for `SystemStats`:

```go
// Before (broken)
SystemStats *SystemStats `json:"system_stats"`

// After (fixed)
SystemStats *SystemStats `json:"system-stats"`
```

The UniFi controller API returns this field as `system-stats` (hyphen), consistent with all other device types — e.g. the `UDM` struct already correctly uses `json:"system-stats"`. The underscore typo caused `SystemStats` to always unmarshal as `nil`, so CPU and memory metrics were never exported for UCI (Cable Internet) devices despite the controller returning the data.

## Verification

Raw API response for a UCI device confirms the field name:
```json
"system-stats": {
  "cpu": "15.8",
  "mem": "89.3",
  "uptime": "711050"
}
```

Comparing with the UDM struct which correctly parses the same field and exports metrics successfully.