### PR TITLE
ref: Added Proxy Env Option

### DIFF
--- a/unifi.go
+++ b/unifi.go
@@ -115,6 +115,7 @@ func newUnifi(config *Config, jar http.CookieJar) *Unifi {
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: !config.VerifySSL, // nolint: gosec
 			},
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 
@@ -298,6 +299,7 @@ func (u *Unifi) checkNewStyleAPI() error {
 		},
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !u.VerifySSL}, // nolint: gosec
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 


### PR DESCRIPTION
Running Unpoller behind a forward proxy currently fails because the unifi lib doesn't recognize common proxy env vars.

This PR adds those. If none are set, [it is ignored](https://cs.opensource.google/go/x/net/+/refs/tags/v0.53.0:http/httpproxy/proxy.go;l=137). If they are set (e.g. by Docker) it will use them.

Confirmed with a local change and custom build which can be found here: https://hub.docker.com/r/afolksetapart/unpoller-proxy

Thanks for your consideration!