### PR TITLE
fix(remote): decompress gzip bodies when Site Manager proxy strips Content-Encoding

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1,6 +1,8 @@
 package unifi
 
 import (
+	"bytes"
+	"compress/gzip"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -182,6 +184,11 @@ func (c *RemoteAPIClient) makeRequestOnce(method, path string, queryParams map[s
 		return nil, fmt.Errorf("reading response: %w", err)
 	}
 
+	body, err = maybeDecompressGzip(body)
+	if err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
 	if resp.StatusCode == http.StatusTooManyRequests {
 		after := parseRetryAfter(resp.Header.Get("Retry-After"))
 
@@ -216,6 +223,34 @@ func (c *RemoteAPIClient) makeRequestOnce(method, path string, queryParams map[s
 	}
 
 	return body, nil
+}
+
+// maybeDecompressGzip returns body decompressed when it begins with the gzip
+// magic bytes (0x1f 0x8b). Otherwise it returns body unchanged.
+//
+// Go's http.Transport transparently decompresses gzip responses only when the
+// upstream sets Content-Encoding: gzip. Some upstream proxies (notably the
+// UniFi Site Manager when fronting Cloud Hosted consoles) return a gzipped
+// payload but strip Content-Encoding, leaving the client with raw compressed
+// bytes. Detecting the magic prefix lets us recover transparently.
+// See unpoller/unpoller#997.
+func maybeDecompressGzip(body []byte) ([]byte, error) {
+	if len(body) < 2 || body[0] != 0x1f || body[1] != 0x8b {
+		return body, nil
+	}
+
+	r, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating gzip reader: %w", err)
+	}
+	defer r.Close()
+
+	decompressed, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading gzip body: %w", err)
+	}
+
+	return decompressed, nil
 }
 
 // getErrorSuggestions provides helpful suggestions for common API errors.

--- a/remote.go
+++ b/remote.go
@@ -184,9 +184,18 @@ func (c *RemoteAPIClient) makeRequestOnce(method, path string, queryParams map[s
 		return nil, fmt.Errorf("reading response: %w", err)
 	}
 
-	body, err = maybeDecompressGzip(body)
-	if err != nil {
-		return nil, fmt.Errorf("decoding response: %w", err)
+	// Decompression failures on error responses must not mask the HTTP status:
+	// the 64 KiB LimitReader above truncates large gzipped error bodies, and a
+	// rate-limited (429) response with a malformed gzip body must still surface
+	// as *RateLimitError so makeRequest can retry. On 2xx, decompression is the
+	// only way to get usable JSON, so failures are fatal.
+	decompressed, decErr := maybeDecompressGzip(body)
+	if decErr != nil && resp.StatusCode < 400 {
+		return nil, fmt.Errorf("decoding response from %s (status %d): %w", path, resp.StatusCode, decErr)
+	}
+
+	if decErr == nil {
+		body = decompressed
 	}
 
 	if resp.StatusCode == http.StatusTooManyRequests {
@@ -243,11 +252,18 @@ func maybeDecompressGzip(body []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating gzip reader: %w", err)
 	}
-	defer r.Close()
 
 	decompressed, err := io.ReadAll(r)
 	if err != nil {
+		_ = r.Close()
+
 		return nil, fmt.Errorf("reading gzip body: %w", err)
+	}
+
+	// Close surfaces CRC32/ISIZE mismatches; without this a corrupted-but-
+	// readable gzip stream silently produces truncated JSON downstream.
+	if err := r.Close(); err != nil {
+		return nil, fmt.Errorf("verifying gzip body: %w", err)
 	}
 
 	return decompressed, nil

--- a/remote_test.go
+++ b/remote_test.go
@@ -1,0 +1,125 @@
+package unifi // nolint: testpackage
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gzipBytes(t *testing.T, payload []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	return buf.Bytes()
+}
+
+func TestMaybeDecompressGzip_NoMagic_PassesThrough(t *testing.T) {
+	t.Parallel()
+
+	in := []byte(`{"data":[]}`)
+
+	out, err := maybeDecompressGzip(in)
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestMaybeDecompressGzip_ShortBody_PassesThrough(t *testing.T) {
+	t.Parallel()
+
+	out, err := maybeDecompressGzip([]byte{0x1f})
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x1f}, out)
+}
+
+func TestMaybeDecompressGzip_GzipMagic_Decompresses(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"data":[{"id":"abc","name":"default"}]}`)
+	compressed := gzipBytes(t, payload)
+
+	out, err := maybeDecompressGzip(compressed)
+	require.NoError(t, err)
+	assert.Equal(t, payload, out)
+}
+
+func TestMaybeDecompressGzip_InvalidGzip_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Magic bytes present but body is otherwise invalid gzip.
+	bad := []byte{0x1f, 0x8b, 0x00, 0x00}
+
+	_, err := maybeDecompressGzip(bad)
+	require.Error(t, err)
+}
+
+// TestDiscoverSites_GzipBodyWithoutContentEncoding reproduces unpoller/unpoller#997:
+// the Site Manager proxy returns a gzipped body but does not set
+// Content-Encoding: gzip, so Go's transport hands raw compressed bytes to the
+// client. The library must detect and decompress the body itself.
+func TestDiscoverSites_GzipBodyWithoutContentEncoding(t *testing.T) {
+	t.Parallel()
+
+	resp := SitesResponse{
+		Data: []RemoteSite{
+			{ID: "site-1", Name: "default", Description: "Default"},
+		},
+		HTTPStatusCode: 200,
+		TraceID:        "trace-xyz",
+	}
+
+	payload, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Intentionally do NOT set Content-Encoding: gzip — this mirrors the
+		// upstream Site Manager behavior described in the bug report.
+		_, _ = w.Write(gzipBytes(t, payload))
+	}))
+	defer srv.Close()
+
+	client := NewRemoteAPIClient("test-key", nil, nil, nil)
+	client.baseURL = srv.URL
+
+	sites, err := client.DiscoverSites("console-1")
+	require.NoError(t, err)
+	require.Len(t, sites, 1)
+	assert.Equal(t, "default", sites[0].Name)
+}
+
+func TestDiscoverSites_PlainJSONBody(t *testing.T) {
+	t.Parallel()
+
+	resp := SitesResponse{
+		Data: []RemoteSite{{ID: "s1", Name: "default"}},
+	}
+
+	payload, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	client := NewRemoteAPIClient("test-key", nil, nil, nil)
+	client.baseURL = srv.URL
+
+	sites, err := client.DiscoverSites("console-1")
+	require.NoError(t, err)
+	require.Len(t, sites, 1)
+	assert.Equal(t, "default", sites[0].Name)
+}

--- a/remote_test.go
+++ b/remote_test.go
@@ -62,6 +62,42 @@ func TestMaybeDecompressGzip_InvalidGzip_ReturnsError(t *testing.T) {
 
 	_, err := maybeDecompressGzip(bad)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gzip")
+}
+
+func TestMaybeDecompressGzip_EmptyBody_PassesThrough(t *testing.T) {
+	t.Parallel()
+
+	out, err := maybeDecompressGzip(nil)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	out, err = maybeDecompressGzip([]byte{})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestMaybeDecompressGzip_TruncatedAfterHeader_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	full := gzipBytes(t, []byte(`{"data":[]}`))
+	// Keep the magic+header but truncate the deflate stream.
+	truncated := full[:10]
+
+	_, err := maybeDecompressGzip(truncated)
+	require.Error(t, err)
+}
+
+func TestMaybeDecompressGzip_CRCMismatch_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	full := gzipBytes(t, []byte(`{"data":[]}`))
+	// Corrupt the CRC32 in the trailer (last 8 bytes are CRC32 + ISIZE).
+	corrupted := append([]byte(nil), full...)
+	corrupted[len(corrupted)-8] ^= 0xff
+
+	_, err := maybeDecompressGzip(corrupted)
+	require.Error(t, err)
 }
 
 // TestDiscoverSites_GzipBodyWithoutContentEncoding reproduces unpoller/unpoller#997:
@@ -97,6 +133,55 @@ func TestDiscoverSites_GzipBodyWithoutContentEncoding(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sites, 1)
 	assert.Equal(t, "default", sites[0].Name)
+}
+
+// TestMakeRequestOnce_GzippedRateLimit_PreservesStatus locks in that
+// decompression failures on error responses do not mask the HTTP status. A 429
+// with a malformed gzip body must still surface as *RateLimitError so
+// makeRequest can honor Retry-After. The 64 KiB LimitReader on error bodies
+// makes truncated gzip streams a realistic failure mode.
+//
+// Calls makeRequestOnce directly to skip the retry loop's Retry-After sleep.
+func TestMakeRequestOnce_GzippedRateLimit_PreservesStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+		// Magic prefix + truncated stream — would fail gzip decode.
+		_, _ = w.Write([]byte{0x1f, 0x8b, 0x08, 0x00, 0x00})
+	}))
+	defer srv.Close()
+
+	client := NewRemoteAPIClient("test-key", nil, nil, nil)
+	client.baseURL = srv.URL
+
+	_, err := client.makeRequestOnce("GET", "/v1/anything", nil)
+	require.Error(t, err)
+
+	var rateErr *RateLimitError
+	assert.ErrorAs(t, err, &rateErr, "gzip decode failure must not mask 429 status")
+}
+
+// TestMakeRequestOnce_GzippedErrorBody_PreservesStatus ensures a 4xx with a
+// malformed gzip body still surfaces a status-aware error rather than the
+// generic "decoding response" error.
+func TestMakeRequestOnce_GzippedErrorBody_PreservesStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		// Magic prefix + truncated stream.
+		_, _ = w.Write([]byte{0x1f, 0x8b, 0x08, 0x00, 0x00})
+	}))
+	defer srv.Close()
+
+	client := NewRemoteAPIClient("test-key", nil, nil, nil)
+	client.baseURL = srv.URL
+
+	_, err := client.makeRequestOnce("GET", "/v1/anything", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403", "decompression failure must not hide HTTP status")
 }
 
 func TestDiscoverSites_PlainJSONBody(t *testing.T) {


### PR DESCRIPTION
## Summary
- Detect the gzip magic prefix (`\x1f\x8b`) on remote-API response bodies and decompress before returning, so JSON parsing succeeds even when the upstream proxy returns compressed bytes without a `Content-Encoding: gzip` header.
- Add unit tests for `maybeDecompressGzip` (pass-through, gzip-magic, short-body, malformed gzip) and an integration-style `httptest` test that reproduces the Site Manager behavior described in the linked issue.

## Background
Reported in unpoller/unpoller#997. When unpoller uses Remote API mode (`remote: true` + Site Manager `api_key`) against an Official UniFi Cloud Hosted console (`*.unifi-hosting.ui.com`), site discovery fails with:

```
parsing sites response: invalid character '\x1f' looking for beginning of value
```

`\x1f` is the first byte of the gzip magic header. Go's `http.Transport` only auto-decompresses when the response advertises `Content-Encoding: gzip`. The Site Manager proxy serves Cloud Hosted console payloads as gzip but strips that header, so raw compressed bytes reach `json.Unmarshal`.

The user has no workaround: Cloud Hosted consoles disable local users (mandatory SSO + 2FA), and the Site Manager API key is rejected at the local controller URL.

## Fix
`makeRequestOnce` in `remote.go` now calls `maybeDecompressGzip` after reading the response body. The helper inspects the first two bytes; if they match the gzip magic, it decompresses via `compress/gzip`. Otherwise the body is returned unchanged. This is safe even when Go's transport already decompressed the body (transport-decompressed bodies don't begin with the gzip magic).

## Test plan
- [x] `go test ./...` (all green)
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] New `httptest` server returns gzip-encoded body without `Content-Encoding` header → `DiscoverSites` succeeds
- [x] Plain-JSON response still works
- [ ] Manual verification by an affected user against a Cloud Hosted console

Fixes unpoller/unpoller#997