### PR TITLE
fix(local): decompress gzip bodies when proxy strips Content-Encoding

### DIFF
--- a/unifi.go
+++ b/unifi.go
@@ -561,6 +561,29 @@ func (u *Unifi) do(req *http.Request) ([]byte, error) {
 		return body, fmt.Errorf("reading response: %w", err)
 	}
 
+	// Decompression failures on error responses must not mask the HTTP status:
+	// a 4xx/5xx with a malformed gzip body must still surface as the right
+	// status-aware error so callers (and any retry logic) can react. On 2xx,
+	// decompression is the only way to get usable JSON, so failures are fatal.
+	//
+	// Some upstreams (notably the UniFi Site Manager when fronting Cloud
+	// Hosted consoles) gzip the body but strip Content-Encoding, leaving the
+	// Go transport unable to decompress it. See unpoller/unpoller#997.
+	decompressed, decErr := maybeDecompressGzip(body)
+	if decErr != nil && resp.StatusCode < 400 {
+		return body, fmt.Errorf("decoding response from %s: %w", req.URL, decErr)
+	}
+
+	if decErr != nil {
+		// Status-aware error wins below, but record the decode failure so a
+		// misbehaving upstream emitting corrupt gzip on error responses is not
+		// invisible during diagnosis. body is left as the original raw bytes.
+		u.DebugLog("gzip decode failed for %s (status %d), returning raw body: %v",
+			req.URL, resp.StatusCode, decErr)
+	} else {
+		body = decompressed
+	}
+
 	// Save the returned CSRF header.
 	if csrf := resp.Header.Get("x-csrf-token"); csrf != "" {
 		u.csrf = resp.Header.Get("x-csrf-token")

--- a/unifi_test.go
+++ b/unifi_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewUnifiNilConfig(t *testing.T) {
@@ -205,3 +206,163 @@ func TestRateLimitError(t *testing.T) {
 a.EqualValues(`{"username": "user1","password": "pass2"}`, string(post_params),
 	"user/pass json parameters improperly encoded")
 */
+
+// TestDo_GzipBodyWithoutContentEncoding mirrors unpoller/unpoller#997 on the
+// local controller path: a proxy returns a gzipped JSON body but does not set
+// Content-Encoding, so Go's transport hands raw compressed bytes to the
+// client. The library must detect and decompress the body itself.
+func TestDo_GzipBodyWithoutContentEncoding(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"data":[{"name":"default"}],"meta":{"rc":"ok"}}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Intentionally do NOT set Content-Encoding: gzip.
+		_, _ = w.Write(gzipBytes(t, payload))
+	}))
+	defer srv.Close()
+
+	u := &Unifi{Client: srv.Client(), Config: &Config{URL: srv.URL, DebugLog: discardLogs}}
+
+	got, err := u.GetJSON("/api/s/default/self/sites")
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+// truncatedGzip returns a valid gzip header followed by a cut-off deflate
+// stream that fails to decode. Used to simulate a corrupt-but-magic-prefixed
+// body on error responses.
+func truncatedGzip() []byte {
+	return []byte{0x1f, 0x8b, 0x08, 0x00, 0x00}
+}
+
+// TestDo_GzippedRateLimit_PreservesStatus locks in that decompression failures
+// on error responses do not mask the HTTP status. A 429 with a malformed gzip
+// body must still surface as *RateLimitError, and the raw (undecoded) body
+// must be returned alongside the error so callers can still log it.
+func TestDo_GzippedRateLimit_PreservesStatus(t *testing.T) {
+	t.Parallel()
+
+	raw := truncatedGzip()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write(raw)
+	}))
+	defer srv.Close()
+
+	u := &Unifi{Client: srv.Client(), Config: &Config{URL: srv.URL, DebugLog: discardLogs}}
+
+	got, err := u.GetJSON("/api/s/default/self/sites")
+	require.Error(t, err)
+
+	var rateErr *RateLimitError
+	assert.ErrorAs(t, err, &rateErr, "gzip decode failure must not mask 429 status")
+	assert.Equal(t, raw, got, "raw body must be returned when gzip decode fails on error responses")
+}
+
+// TestDo_GzippedNotFound_PreservesStatus ensures a 404 with a malformed gzip
+// body still surfaces ErrEndpointNotFound rather than the generic decoding
+// error, since callers (e.g. endpoint probes) rely on the sentinel.
+func TestDo_GzippedNotFound_PreservesStatus(t *testing.T) {
+	t.Parallel()
+
+	raw := truncatedGzip()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(raw)
+	}))
+	defer srv.Close()
+
+	u := &Unifi{Client: srv.Client(), Config: &Config{URL: srv.URL, DebugLog: discardLogs}}
+
+	got, err := u.GetJSON("/api/s/default/self/sites")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEndpointNotFound, "decompression failure must not hide 404")
+	assert.Equal(t, raw, got, "raw body must be returned when gzip decode fails on error responses")
+}
+
+// TestDo_GzippedServerError_PreservesStatus covers the generic non-2xx,
+// non-404, non-429 branch: a 500 with a malformed gzip body must still surface
+// ErrInvalidStatusCode so callers checking the sentinel still work.
+func TestDo_GzippedServerError_PreservesStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(truncatedGzip())
+	}))
+	defer srv.Close()
+
+	u := &Unifi{Client: srv.Client(), Config: &Config{URL: srv.URL, DebugLog: discardLogs}}
+
+	_, err := u.GetJSON("/api/s/default/self/sites")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidStatusCode, "decompression failure must not hide 500")
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestDo_GzippedSuccess_DecompressionFailureIsFatal ensures a 2xx response
+// with a malformed gzip body is reported as an error (and not silently passed
+// through as raw bytes to the JSON parser).
+func TestDo_GzippedSuccess_DecompressionFailureIsFatal(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(truncatedGzip())
+	}))
+	defer srv.Close()
+
+	u := &Unifi{Client: srv.Client(), Config: &Config{URL: srv.URL, DebugLog: discardLogs}}
+
+	_, err := u.GetJSON("/api/s/default/self/sites")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding response")
+}
+
+// TestDo_GzippedServerError_ValidGzip_ReturnsDecompressedBody covers the
+// remaining branch where decompression *succeeds* on a non-2xx response: the
+// status-aware sentinel must still fire, and the caller must receive the
+// decompressed (not the raw gzipped) body so error logging is readable.
+func TestDo_GzippedServerError_ValidGzip_ReturnsDecompressedBody(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"meta":{"rc":"error","msg":"api.err.ServerError"}}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(gzipBytes(t, payload))
+	}))
+	defer srv.Close()
+
+	u := &Unifi{Client: srv.Client(), Config: &Config{URL: srv.URL, DebugLog: discardLogs}}
+
+	got, err := u.GetJSON("/api/s/default/self/sites")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidStatusCode)
+	assert.Equal(t, payload, got, "decompressed body must be returned when gzip decode succeeds, even on error status")
+}
+
+// TestDo_PlainJSONBody is the non-gzipped baseline so we know the decompress
+// hook does not interfere with normal responses.
+func TestDo_PlainJSONBody(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"data":[{"name":"default"}],"meta":{"rc":"ok"}}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	u := &Unifi{Client: srv.Client(), Config: &Config{URL: srv.URL, DebugLog: discardLogs}}
+
+	got, err := u.GetJSON("/api/s/default/self/sites")
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}


### PR DESCRIPTION
## Summary

- Apply the `maybeDecompressGzip` helper (introduced in #220 for `remote.go`) to the local-controller `do()` path so the library tolerates upstreams that gzip the body but strip `Content-Encoding: gzip`.
- Decompression failures on 2xx are fatal; on `>=400` the gzip error is logged via `DebugLog` and dropped so the status-aware sentinels (`*RateLimitError`, `ErrEndpointNotFound`, `ErrInvalidStatusCode`) still win for callers that depend on them via `errors.Is`/`errors.As`.

## Why

unpoller/unpoller#997 reports that Unpoller fails site discovery against Official UniFi Cloud Hosted consoles (`*.unifi-hosting.ui.com`) with `invalid character '\x1f' looking for beginning of value`. The Site Manager proxy fronting those consoles returns gzipped JSON without the `Content-Encoding` header, so Go's transport hands raw compressed bytes to `json.Unmarshal`. PR #220 fixed this for the Site Manager Remote API path; this PR applies the same principle to the local controller path used by `GetSites`/`GetClients`/etc.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New tests cover the full branch matrix in `do()`:
  - gzipped 200 happy path → decompressed body returned
  - gzipped 429 (malformed) → `*RateLimitError`, raw body preserved
  - gzipped 404 (malformed) → `ErrEndpointNotFound`, raw body preserved
  - gzipped 500 (malformed) → `ErrInvalidStatusCode`
  - gzipped 500 (valid) → decompressed body returned alongside sentinel
  - gzipped 200 (malformed) → fatal `decoding response` error
  - plain JSON baseline → no regression
- [ ] Verify against a real Cloud Hosted console once the change is in unpoller

🤖 Generated with [Claude Code](https://claude.com/claude-code)