### PR TITLE
Fix UBB.peer_ubb.downlink_lldp_macs Unmarshalling Error

### DIFF
--- a/ubb.go
+++ b/ubb.go
@@ -167,7 +167,7 @@ type UBB struct {
 	DisconnectedAt            FlexInt         `json:"disconnected_at"`
 	DisconnectionReason       string          `json:"disconnection_reason"`
 	DisplayableVersion        string          `json:"displayable_version"`
-	DownlinkLLDPMacs          []LLDPTable     `fakesize:"1"                        json:"downlink_lldp_macs"`
+	DownlinkLLDPMacs          []string        `fakesize:"1"                        json:"downlink_lldp_macs"`
 	DownlinkTable             []DownlinkTable `fakesize:"1"                        json:"downlink_table"`
 	EthernetTable             []EthernetTable `fakesize:"1"                        json:"ethernet_table"`
 	FixedApAvailable          FlexBool        `json:"fixed_ap_available"`


### PR DESCRIPTION
As noted in https://github.com/unpoller/unpoller/issues/996 , https://github.com/unpoller/unpoller/issues/409, and similar to https://github.com/unpoller/unpoller/issues/821 

Unmarshalling the UBB.peer_ubb.downlink_lldp_macs struct fails; marshaller attempts to unmarshall to a LLDPTable, but the actual data returned to be a list of strings (MAC addresses). 

Simply adjusted the list type to string and now working on a custom build with no issues. 