### PR TITLE
Support UPS-2U-Pro outlet metrics

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -215,7 +215,7 @@ func (u *Unifi) parseDevices(data []json.RawMessage, site *Site) *Devices {
 			} else {
 				u.unmarshallUSW(site, r, devices)
 			}
-		case "pdu":
+		case "pdu", "usp":
 			u.unmarshallPDU(site, r, devices)
 		case "udm":
 			u.unmarshallUDM(site, r, devices)
@@ -264,11 +264,10 @@ func (u *Unifi) unmarshallUSW(site *Site, payload json.RawMessage, devices *Devi
 
 func (u *Unifi) unmarshallPDU(site *Site, payload json.RawMessage, devices *Devices) {
 	dev := &PDU{SiteName: site.SiteName, SourceName: u.URL}
-	// Note: UniFi API returns type="usw" for PDU devices, so we unmarshal as "usw"
-	// but then set the Type field to "pdu" to correctly identify it
+	// UniFi reports PDU devices as "usw" or "usp", so normalize both as "pdu".
 	if u.unmarshalDevice("usw", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
-		dev.Type = "pdu" // Correct the type field since API incorrectly returns "usw"
+		dev.Type = "pdu"
 		dev.site = site
 		devices.PDUs = append(devices.PDUs, dev)
 	}

--- a/examples/usp.json
+++ b/examples/usp.json
@@ -1,0 +1,105 @@
+{
+  "_id": "synthetic-device-id",
+  "device_id": "synthetic-device-id",
+  "site_id": "synthetic-site-id",
+  "name": "Synthetic UPS-2U-Pro",
+  "mac": "02:00:00:00:00:01",
+  "serial": "SYNTHETIC000001",
+  "ip": "192.0.2.10",
+  "type": "usp",
+  "model": "USPDA2B",
+  "shortname": "UPSPROUS",
+  "adopted": true,
+  "state": 1,
+  "outlet_enabled": true,
+  "outlet_table": [
+    {
+      "index": 1,
+      "name": "Outlet 1",
+      "cycle_enabled": true,
+      "relay_state": true,
+      "outlet_caps": 3,
+      "outlet_voltage": 120.4,
+      "outlet_current": 0.125,
+      "outlet_power": 15.05,
+      "outlet_power_factor": 0.99
+    },
+    {
+      "index": 2,
+      "name": "Outlet 2",
+      "cycle_enabled": true,
+      "relay_state": true,
+      "outlet_caps": 3,
+      "outlet_voltage": 120.3,
+      "outlet_current": 0.25,
+      "outlet_power": 29.8,
+      "outlet_power_factor": 0.98
+    },
+    {
+      "index": 3,
+      "name": "Outlet 3",
+      "cycle_enabled": true,
+      "relay_state": false,
+      "outlet_caps": 3,
+      "outlet_voltage": 120.5,
+      "outlet_current": 0,
+      "outlet_power": 0,
+      "outlet_power_factor": 0
+    },
+    {
+      "index": 4,
+      "name": "Outlet 4",
+      "cycle_enabled": true,
+      "relay_state": true,
+      "outlet_caps": 3,
+      "outlet_voltage": 120.2,
+      "outlet_current": 0.875,
+      "outlet_power": 103.75,
+      "outlet_power_factor": 0.97
+    },
+    {
+      "index": 5,
+      "name": "Outlet 5",
+      "cycle_enabled": true,
+      "relay_state": true,
+      "outlet_caps": 3,
+      "outlet_voltage": 120.1,
+      "outlet_current": 1.125,
+      "outlet_power": 132.4,
+      "outlet_power_factor": 0.98
+    },
+    {
+      "index": 6,
+      "name": "Outlet 6",
+      "cycle_enabled": true,
+      "relay_state": true,
+      "outlet_caps": 3,
+      "outlet_voltage": 120,
+      "outlet_current": 0.055,
+      "outlet_power": 5.9,
+      "outlet_power_factor": 0.89
+    },
+    {
+      "index": 7,
+      "name": "Outlet 7",
+      "cycle_enabled": true,
+      "relay_state": true,
+      "outlet_caps": 3,
+      "outlet_voltage": 119.9,
+      "outlet_current": 0.41,
+      "outlet_power": 47.2,
+      "outlet_power_factor": 0.96
+    },
+    {
+      "index": 8,
+      "name": "Outlet 8",
+      "cycle_enabled": true,
+      "relay_state": true,
+      "outlet_caps": 3,
+      "outlet_voltage": 120.6,
+      "outlet_current": 2.015,
+      "outlet_power": 238.7,
+      "outlet_power_factor": 0.99
+    }
+  ]
+}

--- a/ups_test.go
+++ b/ups_test.go
@@ -1,0 +1,61 @@
+package unifi // nolint: testpackage
+
+import (
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed examples/usp.json
+var upsTwoUProSample []byte
+
+func TestParseDevicesUPS2UPro(t *testing.T) {
+	t.Parallel()
+
+	client := &Unifi{Config: &Config{
+		URL:      "https://synthetic-controller.example",
+		ErrorLog: discardLogs,
+		DebugLog: discardLogs,
+	}}
+	site := &Site{SiteName: "Synthetic Site"}
+	devices := client.parseDevices([]json.RawMessage{upsTwoUProSample}, site)
+
+	require.Empty(t, devices.USWs)
+	require.Len(t, devices.PDUs, 1)
+
+	pdu := devices.PDUs[0]
+	require.Equal(t, "pdu", pdu.Type)
+	require.Equal(t, "USPDA2B", pdu.Model)
+	require.Equal(t, "Synthetic UPS-2U-Pro", pdu.Name)
+	require.Equal(t, "02:00:00:00:00:01", pdu.Mac)
+	require.Equal(t, "Synthetic Site", pdu.SiteName)
+	require.Len(t, pdu.OutletTable, 8)
+
+	expectedMetrics := []struct {
+		voltage     float64
+		current     float64
+		power       float64
+		powerFactor float64
+	}{
+		{voltage: 120.4, current: 0.125, power: 15.05, powerFactor: 0.99},
+		{voltage: 120.3, current: 0.25, power: 29.8, powerFactor: 0.98},
+		{voltage: 120.5, current: 0, power: 0, powerFactor: 0},
+		{voltage: 120.2, current: 0.875, power: 103.75, powerFactor: 0.97},
+		{voltage: 120.1, current: 1.125, power: 132.4, powerFactor: 0.98},
+		{voltage: 120, current: 0.055, power: 5.9, powerFactor: 0.89},
+		{voltage: 119.9, current: 0.41, power: 47.2, powerFactor: 0.96},
+		{voltage: 120.6, current: 2.015, power: 238.7, powerFactor: 0.99},
+	}
+
+	for index, expected := range expectedMetrics {
+		outlet := pdu.OutletTable[index]
+
+		require.Equal(t, float64(index+1), outlet.Index.Val)
+		require.InDelta(t, expected.voltage, outlet.OutletVoltage.Val, 0.001)
+		require.InDelta(t, expected.current, outlet.OutletCurrent.Val, 0.001)
+		require.InDelta(t, expected.power, outlet.OutletPower.Val, 0.001)
+		require.InDelta(t, expected.powerFactor, outlet.OutletPowerFactor.Val, 0.001)
+	}
+}


### PR DESCRIPTION
## Summary

- route UniFi Network devices reported as `type: "usp"` through the existing PDU unmarshal path
- preserve PDU normalization to `type: "pdu"` without model-specific handling
- add a sanitized UPS-2U-Pro fixture and regression coverage for all eight outlets and their numeric voltage, current, power, and power-factor values

Related to unpoller/unpoller#1047.

## Testing

- `go test ./... -run '^TestParseDevicesUPS2UPro$' -count=1`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`