### PR TITLE
feat: add UNAS Pro (UniFi Drive) API support

### DIFF
--- a/endpoints_data/ENDPOINTS.md
+++ b/endpoints_data/ENDPOINTS.md
@@ -385,4 +385,33 @@ This API supports both reads and writes. `siteId` is the UUID from `GET /v1/site
 
 ---
 
+## UNAS Pro (UniFi Drive API)
+
+Served by a UNAS Pro console, not by the Network application, so there is no `/proxy/network`
+prefix and no site in the path. Responses are bare JSON objects — no `{"meta":…,"data":…}`
+envelope. Implemented in `unas.go` via `NewUNASClient`; see unpoller/unpoller#785.
+
+| Method | Path | Data exposed |
+|--------|------|----------------|
+| GET | `/proxy/drive/api/v2/systems/device-info` | Name, model, version, firmware, startup time, CPU load/temperature, memory free/total/available, network interfaces. |
+| GET | `/proxy/drive/api/v2/storage` | Storage pools (capacity, usage, status, RAID groups) and physical disks (health score, temperature, power-on hours, RPM, size, bad/uncorrectable sectors, read/write KBPS). |
+| GET | `/proxy/users/drive/api/v2/drives` | Shares: id, name, type, status, pool, quota, usage, member count, protections. |
+| GET | `/proxy/drive/api/v2/systems/network-io` | Instantaneous receive/transmit KBPS. |
+
+Known but not implemented:
+
+| Method | Path | Why not |
+|--------|------|---------|
+| GET | `/proxy/drive/api/v2/systems/disk-stats` | Requires `?start=&end=&interval=`; returns time-series arrays that do not map to gauges. Its per-disk read/write KBPS are already in `/storage`. |
+| GET | `/proxy/drive/api/v1/systems/performance/file-operations` | Not yet needed. |
+| GET | `/proxy/users/drive/api/v1/systems/identity`, `/proxy/users/drive/api/v1/systems/info` | Not yet needed. |
+| GET | `/proxy/users/drive/api/v2/groups`, `/proxy/users/drive/api/v2/storage` | Not yet needed. |
+
+The `unas-*.json` files in this directory are **synthetic**, hand-built from the field set
+above to exercise unmarshalling. They are not captures from a real console. Fields with no
+known populated shape — `usbs`, `cacheSlots`, `expansions`, `riskReasons`,
+`incompatibleReasons` — are kept as `json.RawMessage` until real data turns up.
+
+---
+
 *Generated from a capture session; endpoints may vary by controller version and role. Use the capture script to record your own session and extend this list.*

--- a/endpoints_data/unas-device-info.json
+++ b/endpoints_data/unas-device-info.json
@@ -1,0 +1,37 @@
+{
+  "networkInterfaces": [
+    {
+      "interface": "eth0",
+      "interfaceName": "Port 1",
+      "connected": true,
+      "maxSpeed": "2500",
+      "linkSpeed": "1000",
+      "address": "192.168.1.50",
+      "mac": "aa:bb:cc:dd:ee:ff"
+    },
+    {
+      "interface": "sfp0",
+      "interfaceName": "SFP+ 1",
+      "connected": false,
+      "maxSpeed": "10000",
+      "linkSpeed": "0"
+    }
+  ],
+  "usbs": null,
+  "version": "4.3.5",
+  "name": "UNAS Pro",
+  "model": "UNASPro",
+  "startupTime": "2026-07-01T09:15:02Z",
+  "memory": {
+    "free": 3221225472,
+    "total": 8589934592,
+    "available": 5368709120
+  },
+  "cpu": {
+    "currentLoad": 4.75,
+    "temperature": 46
+  },
+  "firmwareVersion": "4.3.5.1234",
+  "status": "healthy",
+  "sfpAggregation": false
+}

--- a/endpoints_data/unas-drives.json
+++ b/endpoints_data/unas-drives.json
@@ -1,0 +1,25 @@
+{
+  "drives": [
+    {
+      "id": "drive-1",
+      "type": "shared",
+      "name": "media",
+      "status": "healthy",
+      "storagePoolId": "pool-1",
+      "dataSync": "standard",
+      "recordSize": "128K",
+      "compressionLevel": "lz4",
+      "deduplication": "off",
+      "deduplicationEverEnabled": false,
+      "quota": 10000000000000,
+      "usage": 4200000000000,
+      "role": "general",
+      "protections": {
+        "encryptionStatus": "disabled",
+        "remoteBackupEnabled": false,
+        "snapshotEnabled": true
+      },
+      "memberCount": 3
+    }
+  ]
+}

--- a/endpoints_data/unas-network-io.json
+++ b/endpoints_data/unas-network-io.json
@@ -1,0 +1,5 @@
+{
+  "receiveKBPS": 1024.5,
+  "transmitKBPS": 512.25,
+  "timestamp": "2026-08-18T12:00:00Z"
+}

--- a/endpoints_data/unas-storage.json
+++ b/endpoints_data/unas-storage.json
@@ -1,0 +1,92 @@
+{
+  "pools": [
+    {
+      "number": 1,
+      "id": "pool-1",
+      "preferLevel": "RAID5",
+      "type": "hdd",
+      "status": "healthy",
+      "capacity": 60000000000000,
+      "usage": 12500000000000,
+      "activeRaidGroupId": "rg-1",
+      "raidGroups": [
+        {
+          "number": 1,
+          "id": "rg-1",
+          "remnantReason": "",
+          "isSSDCache": false,
+          "currentLevel": "RAID5",
+          "configLevel": "RAID5",
+          "currentProtection": 1,
+          "expectedProtection": 1,
+          "recommendedDiskSize": 20000000000000,
+          "progress": 100,
+          "estimate": 0
+        }
+      ],
+      "initializingStatus": "done"
+    }
+  ],
+  "disks": [
+    {
+      "slotId": "1",
+      "location": "internal",
+      "poolId": "pool-1",
+      "raidGroupId": "rg-1",
+      "metadataGroupId": "",
+      "isGlobalHotSpare": false,
+      "isLocalHotSpare": false,
+      "type": "hdd",
+      "state": "healthy",
+      "rpm": 7200,
+      "model": "WDC WD201KFGX-68BKKN0",
+      "size": 20000588955648,
+      "sata": "3.3",
+      "ata": "8",
+      "nvmeVersion": "",
+      "firmware": "83.00A83",
+      "sectorFormat": "512e",
+      "serial": "SERIAL0001",
+      "temperature": 38,
+      "powerOnHours": 8760,
+      "badSectorCount": 0,
+      "uncorrectableSectorCount": 0,
+      "readErrorRate": 0,
+      "smartReadErrorCount": 0,
+      "riskReasons": [],
+      "incompatibleReasons": [],
+      "readKBPS": 128.5,
+      "writeKBPS": 64.25,
+      "smartTestSupported": true,
+      "healthScore": 100
+    },
+    {
+      "slotId": "2",
+      "location": "internal",
+      "poolId": "pool-1",
+      "raidGroupId": "rg-1",
+      "isGlobalHotSpare": false,
+      "isLocalHotSpare": false,
+      "type": "hdd",
+      "state": "healthy",
+      "rpm": 7200,
+      "model": "WDC WD201KFGX-68BKKN0",
+      "size": 20000588955648,
+      "serial": "SERIAL0002",
+      "temperature": 39,
+      "powerOnHours": 8761,
+      "badSectorCount": 2,
+      "uncorrectableSectorCount": 0,
+      "readErrorRate": 0,
+      "smartReadErrorCount": 1,
+      "riskReasons": [],
+      "incompatibleReasons": [],
+      "readKBPS": 130,
+      "writeKBPS": 60,
+      "smartTestSupported": true,
+      "healthScore": 98
+    }
+  ],
+  "cacheSlots": [],
+  "expansions": null
+}

--- a/types.go
+++ b/types.go
@@ -222,6 +222,13 @@ const (
 	APIIntegrationInfoPath        string = "/proxy/network/integration/v1/info"
 	APICountriesPath              string = "/proxy/network/integration/v1/countries"
 
+	// UNAS Pro (UniFi Drive) API paths. These already start with /proxy/ so path() leaves
+	// them untouched. They are served by a UNAS console, not by the Network application.
+	APIUNASDeviceInfoPath string = "/proxy/drive/api/v2/systems/device-info"
+	APIUNASStoragePath    string = "/proxy/drive/api/v2/storage"
+	APIUNASNetworkIOPath  string = "/proxy/drive/api/v2/systems/network-io"
+	APIUNASDrivesPath     string = "/proxy/users/drive/api/v2/drives"
+
 	// Legacy gap API paths (Part A).
 	APIWANStatusPath   string = "/api/s/%s/stat/status"
 	APIUPSDevicesPath  string = "/api/s/%s/stat/ups-devices"

--- a/unas.go
+++ b/unas.go
@@ -1,0 +1,387 @@
+package unifi
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http/cookiejar"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// UNAS Pro support is a port of https://github.com/alexgreenbank/unaspoller (MIT), which
+// worked out the UniFi Drive JSON API by observing the console's own web UI. Thanks to
+// alexgreenbank for the reverse engineering and for offering the work upstream; see
+// unpoller/unpoller#785.
+
+// unasEndpointCount is the number of endpoints GetUNASDevice polls. It is used to tell a
+// partial failure (report what we have) from a total one (report nothing).
+const unasEndpointCount = 4
+
+// UNASDeviceInfo holds console identity, CPU, and memory data.
+// API Path: /proxy/drive/api/v2/systems/device-info
+type UNASDeviceInfo struct {
+	Name              string                 `json:"name"`
+	Model             string                 `json:"model"`
+	Version           string                 `json:"version"`
+	FirmwareVersion   string                 `json:"firmwareVersion"`
+	Status            string                 `json:"status"`
+	StartupTime       string                 `json:"startupTime"`
+	SfpAggregation    FlexBool               `json:"sfpAggregation"`
+	Memory            UNASMemory             `json:"memory"`
+	CPU               UNASCPU                `json:"cpu"`
+	NetworkInterfaces []UNASNetworkInterface `json:"networkInterfaces"`
+	// Usbs is nullable and its populated shape is unknown; kept raw for diagnosis.
+	Usbs json.RawMessage `fake:"skip" json:"usbs"`
+}
+
+// UNASMemory holds console memory counters, in bytes.
+type UNASMemory struct {
+	Free      FlexInt `json:"free"`
+	Total     FlexInt `json:"total"`
+	Available FlexInt `json:"available"`
+}
+
+// UNASCPU holds console CPU load and temperature.
+type UNASCPU struct {
+	CurrentLoad FlexInt `json:"currentLoad"`
+	Temperature FlexInt `json:"temperature"`
+}
+
+// UNASNetworkInterface describes one console network interface.
+type UNASNetworkInterface struct {
+	Interface     string   `json:"interface"`
+	InterfaceName string   `json:"interfaceName"`
+	Connected     FlexBool `json:"connected"`
+	MaxSpeed      string   `json:"maxSpeed"`
+	LinkSpeed     string   `json:"linkSpeed"`
+	Address       string   `json:"address,omitempty"`
+	MAC           string   `json:"mac,omitempty"`
+}
+
+// UNASStorage holds storage pool and physical disk data.
+// API Path: /proxy/drive/api/v2/storage
+type UNASStorage struct {
+	Pools []UNASPool `json:"pools"`
+	Disks []UNASDisk `json:"disks"`
+	// CacheSlots and Expansions have no known populated shape yet; kept raw for diagnosis.
+	CacheSlots json.RawMessage `fake:"skip" json:"cacheSlots"`
+	Expansions json.RawMessage `fake:"skip" json:"expansions"`
+}
+
+// UNASPool describes one storage pool.
+type UNASPool struct {
+	Number             FlexInt         `json:"number"`
+	ID                 string          `json:"id"`
+	PreferLevel        string          `json:"preferLevel"`
+	Type               string          `json:"type"`
+	Status             string          `json:"status"`
+	Capacity           FlexInt         `json:"capacity"`
+	Usage              FlexInt         `json:"usage"`
+	ActiveRaidGroupID  string          `json:"activeRaidGroupId"`
+	InitializingStatus string          `json:"initializingStatus"`
+	RaidGroups         []UNASRaidGroup `json:"raidGroups"`
+}
+
+// UNASRaidGroup describes one RAID group within a storage pool.
+type UNASRaidGroup struct {
+	Number              FlexInt  `json:"number"`
+	ID                  string   `json:"id"`
+	RemnantReason       string   `json:"remnantReason"`
+	IsSSDCache          FlexBool `json:"isSSDCache"`
+	CurrentLevel        string   `json:"currentLevel"`
+	ConfigLevel         string   `json:"configLevel"`
+	CurrentProtection   FlexInt  `json:"currentProtection"`
+	ExpectedProtection  FlexInt  `json:"expectedProtection"`
+	RecommendedDiskSize FlexInt  `json:"recommendedDiskSize"`
+	Progress            FlexInt  `json:"progress"`
+	Estimate            FlexInt  `json:"estimate"`
+}
+
+// UNASDisk describes one physical disk, including SMART health data.
+type UNASDisk struct {
+	SlotID                   string   `json:"slotId"`
+	Location                 string   `json:"location"`
+	PoolID                   string   `json:"poolId"`
+	RaidGroupID              string   `json:"raidGroupId"`
+	MetadataGroupID          string   `json:"metadataGroupId"`
+	IsGlobalHotSpare         FlexBool `json:"isGlobalHotSpare"`
+	IsLocalHotSpare          FlexBool `json:"isLocalHotSpare"`
+	Type                     string   `json:"type"`
+	State                    string   `json:"state"`
+	RPM                      FlexInt  `json:"rpm"`
+	Model                    string   `json:"model"`
+	Size                     FlexInt  `json:"size"`
+	Sata                     string   `json:"sata"`
+	Ata                      string   `json:"ata"`
+	NvmeVersion              string   `json:"nvmeVersion"`
+	Firmware                 string   `json:"firmware"`
+	SectorFormat             string   `json:"sectorFormat"`
+	Serial                   string   `json:"serial"`
+	Temperature              FlexInt  `json:"temperature"`
+	PowerOnHours             FlexInt  `json:"powerOnHours"`
+	BadSectorCount           FlexInt  `json:"badSectorCount"`
+	UncorrectableSectorCount FlexInt  `json:"uncorrectableSectorCount"`
+	ReadErrorRate            FlexInt  `json:"readErrorRate"`
+	SmartReadErrorCount      FlexInt  `json:"smartReadErrorCount"`
+	ReadKBPS                 FlexInt  `json:"readKBPS"`
+	WriteKBPS                FlexInt  `json:"writeKBPS"`
+	SmartTestSupported       FlexBool `json:"smartTestSupported"`
+	HealthScore              FlexInt  `json:"healthScore"`
+	// RiskReasons and IncompatibleReasons have no known populated shape yet.
+	RiskReasons         json.RawMessage `fake:"skip" json:"riskReasons"`
+	IncompatibleReasons json.RawMessage `fake:"skip" json:"incompatibleReasons"`
+}
+
+// UNASDrive describes one share ("drive") on the console.
+type UNASDrive struct {
+	ID                       string               `json:"id"`
+	Type                     string               `json:"type"`
+	Name                     string               `json:"name"`
+	Status                   string               `json:"status"`
+	StoragePoolID            string               `json:"storagePoolId"`
+	DataSync                 string               `json:"dataSync"`
+	RecordSize               string               `json:"recordSize"`
+	CompressionLevel         string               `json:"compressionLevel"`
+	Deduplication            string               `json:"deduplication"`
+	DeduplicationEverEnabled FlexBool             `json:"deduplicationEverEnabled"`
+	Quota                    FlexInt              `json:"quota"`
+	Usage                    FlexInt              `json:"usage"`
+	Role                     string               `json:"role"`
+	MemberCount              FlexInt              `json:"memberCount"`
+	Protections              UNASDriveProtections `json:"protections"`
+}
+
+// UNASDriveProtections holds the protection settings for a share.
+type UNASDriveProtections struct {
+	EncryptionStatus    string   `json:"encryptionStatus"`
+	RemoteBackupEnabled FlexBool `json:"remoteBackupEnabled"`
+	SnapshotEnabled     FlexBool `json:"snapshotEnabled"`
+}
+
+// UNASNetworkIO holds instantaneous console network throughput.
+// API Path: /proxy/drive/api/v2/systems/network-io
+type UNASNetworkIO struct {
+	ReceiveKBPS  FlexInt `json:"receiveKBPS"`
+	TransmitKBPS FlexInt `json:"transmitKBPS"`
+	Timestamp    string  `json:"timestamp"`
+}
+
+// UNASDevice is the aggregate of every polled UNAS endpoint for one console.
+// Any member may be nil if that endpoint failed; check before dereferencing.
+type UNASDevice struct {
+	DeviceInfo *UNASDeviceInfo `json:"device_info"`
+	Storage    *UNASStorage    `json:"storage"`
+	NetworkIO  *UNASNetworkIO  `json:"network_io"`
+	Drives     []*UNASDrive    `json:"drives"`
+
+	SourceName string `json:"source_name"`
+}
+
+// Name returns the console name, or an empty string if device-info is missing.
+func (d *UNASDevice) Name() string {
+	if d == nil || d.DeviceInfo == nil {
+		return ""
+	}
+
+	return d.DeviceInfo.Name
+}
+
+// Model returns the console model, or an empty string if device-info is missing.
+func (d *UNASDevice) Model() string {
+	if d == nil || d.DeviceInfo == nil {
+		return ""
+	}
+
+	return d.DeviceInfo.Model
+}
+
+// UNASClient talks to a UNAS Pro console's UniFi Drive API.
+//
+// It embeds *Unifi to reuse the login, CSRF, cookie jar, gzip, and rate-limit handling,
+// but it is constructed differently: see NewUNASClient. Drive getters are deliberately
+// not part of the UnifiClient interface, since a UNAS console serves none of the rest of
+// it and mocks.MockUnifi would have to grow methods it can never meaningfully implement.
+type UNASClient struct {
+	*Unifi
+}
+
+// NewUNASClient creates an authenticated client for a UNAS Pro console. Start here for UNAS.
+//
+// This is deliberately not NewUnifi: that constructor finishes with GetServerData(), which
+// GETs /status — rewritten to /proxy/network/status — and a storage-only UNAS console runs
+// no Network application to answer it. So this logs in and stops.
+//
+// API-key auth is rejected for the same reason: Login() uses /status as its login path when
+// Config.APIKey is set.
+func NewUNASClient(config *Config) (*UNASClient, error) {
+	if config == nil {
+		return nil, ErrNilConfig
+	}
+
+	if config.APIKey != "" {
+		return nil, ErrAPIKeyUnsupported
+	}
+
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		return nil, fmt.Errorf("creating cookiejar: %w", err)
+	}
+
+	u := newUnifi(config, jar)
+
+	for i, cert := range config.SSLCert {
+		p, _ := pem.Decode(cert)
+		if p == nil {
+			continue
+		}
+
+		u.fingerprints[i] = fmt.Sprintf("%x", sha256.Sum256(p.Bytes))
+	}
+
+	// A UNAS Pro is always a UniFi OS console, so the new-style API is a given. Setting this
+	// directly rather than calling checkNewStyleAPI() means Login() resolves to
+	// /api/auth/login without depending on how the console answers a GET of /.
+	u.new = true
+
+	client := &UNASClient{Unifi: u}
+
+	if err := u.Login(); err != nil {
+		return client, err
+	}
+
+	return client, nil
+}
+
+// GetUNASDeviceInfo returns console identity, CPU, and memory data.
+func (c *UNASClient) GetUNASDeviceInfo() (*UNASDeviceInfo, error) {
+	if c == nil || c.Unifi == nil {
+		return nil, ErrNilUnifi
+	}
+
+	c.DebugLog("Polling UNAS for device info")
+
+	response := &UNASDeviceInfo{}
+
+	if err := c.GetData(APIUNASDeviceInfoPath, response); err != nil {
+		return nil, fmt.Errorf("fetching UNAS device info: %w", err)
+	}
+
+	return response, nil
+}
+
+// GetUNASStorage returns storage pool and physical disk data.
+func (c *UNASClient) GetUNASStorage() (*UNASStorage, error) {
+	if c == nil || c.Unifi == nil {
+		return nil, ErrNilUnifi
+	}
+
+	c.DebugLog("Polling UNAS for storage")
+
+	response := &UNASStorage{}
+
+	if err := c.GetData(APIUNASStoragePath, response); err != nil {
+		return nil, fmt.Errorf("fetching UNAS storage: %w", err)
+	}
+
+	return response, nil
+}
+
+// GetUNASDrives returns the shares ("drives") configured on the console.
+func (c *UNASClient) GetUNASDrives() ([]*UNASDrive, error) {
+	if c == nil || c.Unifi == nil {
+		return nil, ErrNilUnifi
+	}
+
+	c.DebugLog("Polling UNAS for drives")
+
+	var response struct {
+		Drives []UNASDrive `json:"drives"`
+	}
+
+	if err := c.GetData(APIUNASDrivesPath, &response); err != nil {
+		return nil, fmt.Errorf("fetching UNAS drives: %w", err)
+	}
+
+	drives := make([]*UNASDrive, len(response.Drives))
+
+	for i := range response.Drives {
+		drives[i] = &response.Drives[i]
+	}
+
+	return drives, nil
+}
+
+// GetUNASNetworkIO returns instantaneous console network throughput.
+func (c *UNASClient) GetUNASNetworkIO() (*UNASNetworkIO, error) {
+	if c == nil || c.Unifi == nil {
+		return nil, ErrNilUnifi
+	}
+
+	c.DebugLog("Polling UNAS for network IO")
+
+	response := &UNASNetworkIO{}
+
+	if err := c.GetData(APIUNASNetworkIOPath, response); err != nil {
+		return nil, fmt.Errorf("fetching UNAS network IO: %w", err)
+	}
+
+	return response, nil
+}
+
+// GetUNASDevice polls every UNAS endpoint and returns the aggregate.
+//
+// Every endpoint is attempted even if an earlier one failed, so a console that exposes only
+// some of them still reports what it has. A partial failure is deliberately NOT an error:
+// the failing endpoints are logged to ErrorLog and their fields left nil, because the
+// natural `if err != nil { return }` at the call site would otherwise drop every metric
+// from a console whenever one endpoint 404s. An error is returned only when nothing at all
+// could be fetched, and then the device is nil.
+func (c *UNASClient) GetUNASDevice() (*UNASDevice, error) {
+	if c == nil || c.Unifi == nil {
+		return nil, ErrNilUnifi
+	}
+
+	device := &UNASDevice{SourceName: c.URL}
+	errs := []error{}
+
+	info, err := c.GetUNASDeviceInfo()
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		device.DeviceInfo = info
+	}
+
+	storage, err := c.GetUNASStorage()
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		device.Storage = storage
+	}
+
+	drives, err := c.GetUNASDrives()
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		device.Drives = drives
+	}
+
+	netIO, err := c.GetUNASNetworkIO()
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		device.NetworkIO = netIO
+	}
+
+	if len(errs) == unasEndpointCount {
+		return nil, errors.Join(errs...)
+	}
+
+	for _, err := range errs {
+		c.ErrorLog("UNAS %s: %v", c.URL, err)
+	}
+
+	return device, nil
+}

--- a/unas_test.go
+++ b/unas_test.go
@@ -1,0 +1,362 @@
+package unifi // nolint: testpackage
+
+import (
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unasFixtures maps each UNAS API path to the file serving its response.
+var unasFixtures = map[string]string{
+	APIUNASDeviceInfoPath: "endpoints_data/unas-device-info.json",
+	APIUNASStoragePath:    "endpoints_data/unas-storage.json",
+	APIUNASDrivesPath:     "endpoints_data/unas-drives.json",
+	APIUNASNetworkIOPath:  "endpoints_data/unas-network-io.json",
+}
+
+// newUNASTestClient returns a client pointed at a server that answers the UNAS paths from
+// fixtures. Paths listed in fail are answered with a 500 instead. The returned slice
+// records the paths the client actually requested, in order.
+func newUNASTestClient(t *testing.T, fail ...string) (*UNASClient, *[]string) {
+	t.Helper()
+
+	failed := make(map[string]bool, len(fail))
+	for _, p := range fail {
+		failed[p] = true
+	}
+
+	requested := &[]string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requested = append(*requested, r.URL.Path)
+
+		if failed[r.URL.Path] {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		file, ok := unasFixtures[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		body, err := os.ReadFile(file)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return &UNASClient{Unifi: &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    true,
+	}}, requested
+}
+
+func TestUNASGetDeviceInfo(t *testing.T) {
+	t.Parallel()
+
+	c, requested := newUNASTestClient(t)
+
+	info, err := c.GetUNASDeviceInfo()
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	a := assert.New(t)
+	// The /proxy/ prefix must survive path(): a UNAS console has no /proxy/network app.
+	a.Equal([]string{APIUNASDeviceInfoPath}, *requested)
+	a.Equal("UNAS Pro", info.Name)
+	a.Equal("UNASPro", info.Model)
+	a.Equal("4.3.5", info.Version)
+	a.Equal("4.3.5.1234", info.FirmwareVersion)
+	a.Equal("healthy", info.Status)
+	a.False(info.SfpAggregation.Val)
+	a.InDelta(4.75, info.CPU.CurrentLoad.Val, 0.001)
+	a.Equal(46, info.CPU.Temperature.Int())
+	a.Equal(int64(8589934592), info.Memory.Total.Int64())
+	a.Equal(int64(3221225472), info.Memory.Free.Int64())
+	a.Equal(int64(5368709120), info.Memory.Available.Int64())
+
+	// The reference implementation shipped an empty json tag here, so this never parsed.
+	require.Len(t, info.NetworkInterfaces, 2)
+	a.Equal("eth0", info.NetworkInterfaces[0].Interface)
+	a.True(info.NetworkInterfaces[0].Connected.Val)
+	a.False(info.NetworkInterfaces[1].Connected.Val)
+}
+
+func TestUNASGetStorage(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUNASTestClient(t)
+
+	storage, err := c.GetUNASStorage()
+	require.NoError(t, err)
+	require.NotNil(t, storage)
+	require.Len(t, storage.Pools, 1)
+	require.Len(t, storage.Disks, 2)
+
+	a := assert.New(t)
+	pool := storage.Pools[0]
+	a.Equal("pool-1", pool.ID)
+	a.Equal("healthy", pool.Status)
+	a.Equal(int64(60000000000000), pool.Capacity.Int64())
+	a.Equal(int64(12500000000000), pool.Usage.Int64())
+	// The reference implementation left this field unexported, so it never parsed.
+	a.Equal("rg-1", pool.ActiveRaidGroupID)
+	require.Len(t, pool.RaidGroups, 1)
+	a.Equal("RAID5", pool.RaidGroups[0].CurrentLevel)
+	a.Equal(100, pool.RaidGroups[0].Progress.Int())
+
+	disk := storage.Disks[1]
+	a.Equal("2", disk.SlotID)
+	a.Equal("pool-1", disk.PoolID)
+	a.Equal("SERIAL0002", disk.Serial)
+	a.Equal(7200, disk.RPM.Int())
+	a.Equal(39, disk.Temperature.Int())
+	a.Equal(8761, disk.PowerOnHours.Int())
+	a.Equal(2, disk.BadSectorCount.Int())
+	a.Equal(98, disk.HealthScore.Int())
+	a.InDelta(130, disk.ReadKBPS.Val, 0.001)
+	a.True(disk.SmartTestSupported.Val)
+}
+
+func TestUNASGetDrives(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUNASTestClient(t)
+
+	drives, err := c.GetUNASDrives()
+	require.NoError(t, err)
+	require.Len(t, drives, 1)
+
+	a := assert.New(t)
+	a.Equal("drive-1", drives[0].ID)
+	a.Equal("media", drives[0].Name)
+	a.Equal("pool-1", drives[0].StoragePoolID)
+	a.Equal(int64(10000000000000), drives[0].Quota.Int64())
+	a.Equal(int64(4200000000000), drives[0].Usage.Int64())
+	a.Equal(3, drives[0].MemberCount.Int())
+	a.True(drives[0].Protections.SnapshotEnabled.Val)
+	a.False(drives[0].Protections.RemoteBackupEnabled.Val)
+}
+
+func TestUNASGetNetworkIO(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUNASTestClient(t)
+
+	netIO, err := c.GetUNASNetworkIO()
+	require.NoError(t, err)
+	require.NotNil(t, netIO)
+
+	a := assert.New(t)
+	a.InDelta(1024.5, netIO.ReceiveKBPS.Val, 0.001)
+	a.InDelta(512.25, netIO.TransmitKBPS.Val, 0.001)
+	a.Equal("2026-08-18T12:00:00Z", netIO.Timestamp)
+}
+
+func TestUNASGetDevice(t *testing.T) {
+	t.Parallel()
+
+	c, requested := newUNASTestClient(t)
+
+	device, err := c.GetUNASDevice()
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	a := assert.New(t)
+	a.Len(*requested, unasEndpointCount)
+	a.Equal("UNAS Pro", device.Name())
+	a.Equal("UNASPro", device.Model())
+	a.NotEmpty(device.SourceName)
+	a.NotNil(device.Storage)
+	a.NotNil(device.NetworkIO)
+	a.Len(device.Drives, 1)
+}
+
+func TestUNASGetDevicePartialFailure(t *testing.T) {
+	t.Parallel()
+
+	c, requested := newUNASTestClient(t, APIUNASDrivesPath)
+
+	logged := []string{}
+	c.ErrorLog = func(msg string, v ...any) {
+		logged = append(logged, fmt.Sprintf(msg, v...))
+	}
+
+	device, err := c.GetUNASDevice()
+	// A console that will not serve one endpoint still reports the rest, and a partial
+	// failure is deliberately not an error -- an `if err != nil { return }` at the call
+	// site would otherwise discard every metric this console can still supply.
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	a := assert.New(t)
+	a.Len(logged, 1, "the endpoint that failed is reported through ErrorLog instead")
+	a.Contains(logged[0], "drives")
+	a.Len(*requested, unasEndpointCount, "every endpoint is attempted even after one fails")
+	a.NotNil(device.DeviceInfo)
+	a.NotNil(device.Storage)
+	a.NotNil(device.NetworkIO)
+	a.Empty(device.Drives)
+}
+
+func TestUNASGetDeviceTotalFailure(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUNASTestClient(t,
+		APIUNASDeviceInfoPath, APIUNASStoragePath, APIUNASDrivesPath, APIUNASNetworkIOPath)
+
+	device, err := c.GetUNASDevice()
+	// Total failure is now the only case that returns an error, and it returns no device.
+	require.Error(t, err)
+	require.Nil(t, device)
+	// The joined error names every endpoint, so an operator sees the whole picture at once.
+	require.Contains(t, err.Error(), "device-info")
+	require.Contains(t, err.Error(), "storage")
+	require.Contains(t, err.Error(), "drives")
+	require.Contains(t, err.Error(), "network-io")
+}
+
+func TestUNASNilReceivers(t *testing.T) {
+	t.Parallel()
+
+	var c *UNASClient
+
+	_, err := c.GetUNASDevice()
+	require.ErrorIs(t, err, ErrNilUnifi)
+
+	_, err = (&UNASClient{}).GetUNASDeviceInfo()
+	require.ErrorIs(t, err, ErrNilUnifi)
+
+	var d *UNASDevice
+
+	a := assert.New(t)
+	a.Empty(d.Name())
+	a.Empty(d.Model())
+	a.Empty((&UNASDevice{}).Name())
+	a.Empty((&UNASDevice{}).Model())
+}
+
+func TestNewUNASClientRejectsBadConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewUNASClient(nil)
+	require.ErrorIs(t, err, ErrNilConfig)
+
+	// Key auth routes Login() through /status, which a storage-only console does not serve.
+	_, err = NewUNASClient(&Config{URL: "https://127.0.0.1", APIKey: "abc123"})
+	require.ErrorIs(t, err, ErrAPIKeyUnsupported)
+}
+
+func TestNewUNASClientLogsIn(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotMethod, gotBody string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+
+		w.Header().Set("x-csrf-token", "csrf-abc")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := NewUNASClient(&Config{
+		URL: srv.URL, User: "unpoller", Pass: "secret", DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	a := assert.New(t)
+	// New-style login is assumed rather than probed with a GET of /, which is why no
+	// request other than the login lands on the server.
+	a.True(c.new)
+	a.Equal(APILoginPathNew, gotPath)
+	a.Equal(http.MethodPost, gotMethod)
+	a.Contains(gotBody, `"username":"unpoller"`)
+	a.Equal("csrf-abc", c.csrf)
+}
+
+// TestNewUNASClientPinsSSLCert covers the one place NewUNASClient duplicates logic from
+// NewUnifi: the fingerprint loop. It writes into a slice newUnifi only allocates when
+// SSLCert is non-empty, so an empty-cert regression there is an index panic, not a test
+// failure elsewhere. Logging in over TLS also proves the pin actually matches.
+func TestNewUNASClientPinsSSLCert(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("x-csrf-token", "csrf-abc")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	require.NotNil(t, cert)
+
+	c, err := NewUNASClient(&Config{
+		URL: srv.URL, User: "unpoller", Pass: "secret", SSLCert: [][]byte{cert},
+		DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	a := assert.New(t)
+	a.Len(c.fingerprints, 1)
+	a.NotNil(c.Transport)
+	a.Equal("csrf-abc", c.csrf)
+}
+
+func TestNewUNASClientLoginFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c, err := NewUNASClient(&Config{URL: srv.URL, DebugLog: discardLogs, ErrorLog: discardLogs})
+	require.ErrorIs(t, err, ErrAuthenticationFailed)
+	// The client is returned alongside the error so callers can retry a login on it.
+	require.NotNil(t, c)
+}
+
+func TestUNASStructs(t *testing.T) {
+	t.Parallel()
+
+	var info UNASDeviceInfo
+
+	require.NoError(t, gofakeit.Struct(&info))
+	require.NotEmpty(t, info.Name)
+
+	var storage UNASStorage
+
+	require.NoError(t, gofakeit.Struct(&storage))
+
+	var drive UNASDrive
+
+	require.NoError(t, gofakeit.Struct(&drive))
+	require.NotEmpty(t, drive.ID)
+
+	var netIO UNASNetworkIO
+
+	require.NoError(t, gofakeit.Struct(&netIO))
+}

--- a/unifi.go
+++ b/unifi.go
@@ -34,6 +34,8 @@ var (
 	ErrInvalidSignature     = errors.New("certificate signature does not match")
 	ErrNilUnifi             = errors.New("unifi client is nil")
 	ErrTooManyRequests      = errors.New("429 too many requests")
+	ErrNilConfig            = errors.New("config must not be nil")
+	ErrAPIKeyUnsupported    = errors.New("api key authentication is not supported for this device")
 
 	// Integration/v1 API sentinels.
 	ErrAPIKeyRequired    = errors.New("integration/v1 API requires Config.APIKey to be set")
@@ -59,7 +61,7 @@ func (e *RateLimitError) Unwrap() error {
 // Start here.
 func NewUnifi(config *Config) (*Unifi, error) {
 	if config == nil {
-		return nil, fmt.Errorf("config is nil")
+		return nil, ErrNilConfig
 	}
 
 	var jar http.CookieJar
@@ -299,7 +301,7 @@ func (u *Unifi) checkNewStyleAPI() error {
 		},
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !u.VerifySSL}, // nolint: gosec
-			Proxy: http.ProxyFromEnvironment,
+			Proxy:           http.ProxyFromEnvironment,
 		},
 	}
 

--- a/unifi_test.go
+++ b/unifi_test.go
@@ -20,8 +20,7 @@ func TestNewUnifiNilConfig(t *testing.T) {
 	a := assert.New(t)
 	uni, err := NewUnifi(nil)
 	a.Nil(uni)
-	a.Error(err)
-	a.Contains(err.Error(), "config is nil")
+	a.ErrorIs(err, ErrNilConfig)
 }
 
 func TestNewUnifi(t *testing.T) {


### PR DESCRIPTION
Adds the client and types needed for UNAS Pro storage metrics. This is the library half of [unpoller/unpoller#785](https://github.com/unpoller/unpoller/issues/785) — the unpoller-side input plugin and exporters are a separate follow-up PR and depend on this being tagged.

Ported from [alexgreenbank/unaspoller](https://github.com/alexgreenbank/unaspoller) (MIT, carrying the same David Newhall II copyright header as this repo, so it's cleanly upstreamable). Credited in the `unas.go` header.

## Why a separate constructor

A UNAS Pro is a standalone UniFi OS console with **no Network application**, so `NewUnifi()` can't be used against one: it ends in `GetServerData()` → GET `/status`, which `path()` rewrites to `/proxy/network/status`. Nothing serves that on a storage-only console.

`NewUNASClient` is a login-only constructor that stops after `Login()`. It sets `u.new = true` directly instead of calling `checkNewStyleAPI()` — a UNAS is always a UniFi OS console, so probing GET `/` only adds a way for login to resolve to the wrong path. API-key auth is rejected with `ErrAPIKeyUnsupported`, since `Login()` routes keys through `/status` for the same reason.

These getters are deliberately **not** added to the `UnifiClient` interface: CONVENTIONS.md requires `mocks.MockUnifi` implement every method, and widening it would break the mocks build for no gain.

## Endpoints

All four already start with `/proxy/`, which `path()` passes through untouched, so `GetData` works on them with no changes. They return bare JSON objects — no `{"meta":…,"data":…}` envelope.

| Path | Yields |
|---|---|
| `/proxy/drive/api/v2/systems/device-info` | name, model, firmware, uptime, cpu load/temp, memory |
| `/proxy/drive/api/v2/storage` | pools and disks (health score, temp, power-on hours, sector counts, r/w KBPS) |
| `/proxy/users/drive/api/v2/drives` | per-share id/name/status/quota/usage/member count |
| `/proxy/drive/api/v2/systems/network-io` | receive/transmit KBPS |

Known-but-unimplemented endpoints (disk-stats time-series, file-operations, users/drive v1 identity/info) are listed with reasons in `endpoints_data/ENDPOINTS.md`.

## Partial failure is not an error

`GetUNASDevice` polls all four and attempts every one even after an earlier failure. Failing endpoints are logged to `ErrorLog` and their fields left nil; **only a total failure returns an error**, and then the device is nil.

Returning a device and an error together was the first cut, but it makes the reflexive `if err != nil { return }` at the call site discard every metric a console can still supply whenever one endpoint 404s — exactly the case the partial path exists to serve.

## Two fixes over the reference implementation

Both are dead fields in unaspoller, fixed rather than inherited, and both have explicit test coverage naming the original bug:

1. `NetworkInterfaces` had an **empty** json tag (`json:""`), so it never unmarshalled.
2. `activeRaidGroupId` was **unexported** with a json tag, so it never unmarshalled either. Now `ActiveRaidGroupID`.

⚠️ **The `networkInterfaces` key is an assumption.** The tests prove the tag is wired, not that the key is right — the reference implementation's empty tag means nobody ever verified it. If a real console disagrees, that one tag is the whole fix. Flagged in ENDPOINTS.md; **a UNAS Pro owner could confirm it in a minute and I'd appreciate it.**

Fields of unknown shape (`usbs`, `cacheSlots`, `expansions`, `riskReasons`, `incompatibleReasons`) stay `json.RawMessage` rather than guessing. All numerics/bools use `FlexInt`/`FlexBool` per lib convention — unaspoller's own comments flag several as "float64? only ever seen ints", which the flex types pre-empt.

## Incidental

`NewUnifi` now returns the new `ErrNilConfig` sentinel instead of its own `fmt.Errorf("config is nil")` for the identical condition, so callers get `errors.Is`. One test assertion updated to match.

## Testing

`go test ./...` and `golangci-lint run ./...` are clean. Coverage includes each getter, the `/proxy/` path pass-through, partial vs. total failure, nil receivers, both ported bug fixes, SSL-cert pinning through the constructor, login path/method/body/csrf capture, and login failure still returning a client so callers can retry.

⚠️ **`endpoints_data/unas-*.json` are synthetic, not real captures** — built from the reference implementation's field set. ENDPOINTS.md states this explicitly so nobody treats them as ground truth. **No part of this has been run against real hardware**, which is the main thing I'd want a reviewer with a UNAS Pro to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)