### PR TITLE
feat: add UniFi Protect device metrics support

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -4,7 +4,7 @@ This file provides context for AI coding assistants working with this codebase.
 
 ## Project Overview
 
-This is **github.com/unpoller/unifi/v5**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
+This is **github.com/unpoller/unifi/v6**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
 
 **Entry point**: `unifi.NewUnifi(config *Config)` → authenticated `*Unifi` client.
 

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Unifi Go Library – Project Overview
 
-This repo is **github.com/unpoller/unifi/v5**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
+This repo is **github.com/unpoller/unifi/v6**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
 
 - **Entry point**: `unifi.NewUnifi(config *Config)` → authenticated `*Unifi` client.
 - **Config**: `Config` has `URL`, `User`, `Pass`, optional `APIKey`, `ErrorLog`/`DebugLog`, `SSLCert`, `VerifySSL`.
@@ -18,6 +18,6 @@ This repo is **github.com/unpoller/unifi/v5**: a Go library that connects to a U
 Typical flow: `Config` → `NewUnifi(config)` → `GetSites()` → `GetClients(sites)` / `GetDevices(sites)`. Optionally `GetAlarms`, `GetEvents`, `GetAnomalies`, etc. See `README.md` for a full example.
 
 - **Returns**: `[]*Site`, `[]*Client`, `*Devices` (with `UAPs`, `USWs`, `USGs`, `UDMs`, `UXGs`, `PDUs`, `UBBs`, `UCIs`), plus alarms, events, DPI, traffic. Data is unmarshaled into large structs for consumption; some types have InfluxDB datapoint helpers.
-- **Import**: `github.com/unpoller/unifi/v5`. Logger interface: `ErrorLog` / `DebugLog` accept `(format, args...)`; use `log.Printf` or custom.
+- **Import**: `github.com/unpoller/unifi/v6`. Logger interface: `ErrorLog` / `DebugLog` accept `(format, args...)`; use `log.Printf` or custom.
 
 When adding features: follow existing patterns (e.g. `GetDevices` / `GetClients`), use `GetData` for HTTP, and add tests. Run `golangci-lint` and tests before committing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is **github.com/unpoller/unifi/v5**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
+This is **github.com/unpoller/unifi/v6**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
 
 **Entry point**: `unifi.NewUnifi(config *Config)` → authenticated `*Unifi` client.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is **github.com/unpoller/unifi/v5**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
+This is **github.com/unpoller/unifi/v6**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
 
 **Entry point**: `unifi.NewUnifi(config *Config)` → authenticated `*Unifi` client.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -4,7 +4,7 @@ This file provides coding conventions and project context for AI assistants work
 
 ## Project Overview
 
-This is **github.com/unpoller/unifi/v5**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
+This is **github.com/unpoller/unifi/v6**: a Go library that connects to a Ubiquiti UniFi controller and **pulls** data (clients, devices, sites, alarms, events, etc.). It does **not** update or change controller settings by design.
 
 **Entry point**: `unifi.NewUnifi(config *Config)` → authenticated `*Unifi` client.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here's a working example:
 package main
 
 import "log"
-import "github.com/unpoller/unifi/v5"
+import "github.com/unpoller/unifi/v6"
 
 func main() {
 	c := *unifi.Config{

--- a/acl_rules_test.go
+++ b/acl_rules_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestACLRule(t *testing.T) {

--- a/clients_test.go
+++ b/clients_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestParseClientHistory(t *testing.T) {

--- a/countries_test.go
+++ b/countries_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestCountry(t *testing.T) {

--- a/devices_test.go
+++ b/devices_test.go
@@ -3,7 +3,7 @@ package unifi_test
 import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 	"testing"
 )
 

--- a/dns_policies_test.go
+++ b/dns_policies_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestDNSPolicy(t *testing.T) {

--- a/dpi_catalogue_test.go
+++ b/dpi_catalogue_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestDPIApplication(t *testing.T) {

--- a/endpoints_data/ENDPOINTS.md
+++ b/endpoints_data/ENDPOINTS.md
@@ -445,10 +445,20 @@ Known but not implemented:
 
 The `protect-*.json` files in this directory are **synthetic**, hand-built from the OpenAPI
 spec to exercise unmarshalling, including nullable-numeric fields (`"percentage": null`, etc.).
-They are not captures from real hardware. Fields the spec declares as bare `object` with no
-documented shape — `glassBreakSettings`, `osdSettings`, `ledSettings`, `lcdMessage`,
-`featureFlags` (camera), `smartDetectSettings`, `lightModeSettings`, and the alarm-hub power/
-terminal-status fields — are kept as `json.RawMessage` until real data turns up.
+They are not captures from real hardware. Numeric and boolean fields deliberately use
+`FlexInt`/`FlexBool`/`FlexFloat` uniformly, consistent with the rest of the library, rather than
+nullable pointers: a nullable field reporting JSON `null` (e.g. a sensor with no battery) reads
+as a real zero through these types, and that null/zero distinction is accepted as lost in
+exchange for uniform typing. Fields the spec declares as bare `object` with no documented shape —
+`glassBreakSettings`, `osdSettings`, `ledSettings`, `lcdMessage`, `featureFlags` (camera),
+`smartDetectSettings`, `lightModeSettings`, and the alarm-hub power/terminal-status fields —
+are kept as `json.RawMessage` until real data turns up.
+
+Since these fixtures are hand-authored rather than captured, be aware that `FlexInt`/`FlexBool`/
+`FlexFloat` unmarshal permissively and never error on an unexpected shape (e.g. an object where
+a bool is expected) — a wire-format mismatch against real hardware would fail silently rather
+than surfacing as a test failure here. Field shapes should be reconfirmed against a real console
+per the plan's verification section.
 
 ---
 

--- a/endpoints_data/ENDPOINTS.md
+++ b/endpoints_data/ENDPOINTS.md
@@ -414,4 +414,42 @@ known populated shape — `usbs`, `cacheSlots`, `expansions`, `riskReasons`,
 
 ---
 
+## UniFi Protect (Integration API)
+
+Served by a Protect NVR's official, documented Integration API
+(<https://developer.ui.com/protect/>), not the private bootstrap API. Base path
+`/proxy/protect/integration/v1/...`; auth via `X-API-KEY` (`ProtectAPIKey` in `Config`, falling
+back to `APIKey`), independent of Network's cookie/CSRF or `APIKey` auth. Implemented in
+`protect.go` via `GetProtectDevices`; see unpoller/unpoller#1015.
+
+| Method | Path | Data exposed |
+|--------|------|----------------|
+| GET | `/proxy/protect/integration/v1/meta/info` | Protect application version. Cheapest endpoint; used as the "is Protect installed and is this key valid" probe. |
+| GET | `/proxy/protect/integration/v1/sensors` | Sensors, including SuperLink sensors: battery, wireless signal, temperature/humidity/light readings, open/motion/leak/tamper state and timestamps. |
+| GET | `/proxy/protect/integration/v1/cameras` | Cameras: connection state and a handful of settings. No bandwidth, storage, wifi, or FPS stats — those live only in the private bootstrap API. |
+| GET | `/proxy/protect/integration/v1/lights` | Floodlights: on/off, PIR motion, dark detection, last-motion timestamp. |
+| GET | `/proxy/protect/integration/v1/bridges` | Wireless bridges (e.g. SuperLink Gateways): connection state, paired clients, max clients. |
+| GET | `/proxy/protect/integration/v1/link-stations` | Link stations, including alarm hubs: battery voltage/status, input power, tamper cover, armed state. |
+| GET | `/proxy/protect/integration/v1/nvrs` | The NVR console itself: arm mode/status and breach event count. Returns a single object, not an array. |
+
+Known but not implemented:
+
+| Method | Path | Why not |
+|--------|------|---------|
+| GET | `/proxy/protect/integration/v1/subscribe/{devices,events}` | Websockets; UnPoller is poll-based. |
+| Any write endpoint (PTZ, siren play/stop, talkback, RTSPS stream create/delete, arm-profile mutation, relay/alarm-hub output triggers, file upload, POS ingestion) | UnPoller only reads. |
+| GET | `/proxy/protect/integration/v1/alarm-hubs` | Same schema as `/v1/link-stations` filtered to `isAlarmHub: true`; polling both would double-count every alarm hub. |
+| GET | `/proxy/protect/integration/v1/{viewers,chimes,sirens,fobs,relays,speakers,users,ulp-users,liveviews,arm-profiles,files}` | No metric value in v1; each is a candidate for a future addition once the scaffolding exists. |
+| Cloud connector (`https://api.ui.com/v1/connector/consoles/{consoleId}/proxy/protect/integration`) | Local console only, for now. |
+| Private bootstrap API (`/proxy/protect/api/bootstrap`) | Undocumented and unversioned. Carries richer camera/NVR system stats (wifi quality/strength, video/storage rates, NVR CPU/memory/disk) as a natural phase 2, deliberately deferred. |
+
+The `protect-*.json` files in this directory are **synthetic**, hand-built from the OpenAPI
+spec to exercise unmarshalling, including nullable-numeric fields (`"percentage": null`, etc.).
+They are not captures from real hardware. Fields the spec declares as bare `object` with no
+documented shape — `glassBreakSettings`, `osdSettings`, `ledSettings`, `lcdMessage`,
+`featureFlags` (camera), `smartDetectSettings`, `lightModeSettings`, and the alarm-hub power/
+terminal-status fields — are kept as `json.RawMessage` until real data turns up.
+
+---
+
 *Generated from a capture session; endpoints may vary by controller version and role. Use the capture script to record your own session and extend this list.*

--- a/endpoints_data/protect-bridges.json
+++ b/endpoints_data/protect-bridges.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "bridge-1",
+    "modelKey": "bridge",
+    "state": "CONNECTED",
+    "name": "SuperLink Gateway",
+    "type": "SuperLink",
+    "guid": "guid-bridge-1",
+    "mac": "AABBCC445566",
+    "platform": "superlink",
+    "clients": ["sensor-1", "sensor-2"],
+    "maxClients": 32
+  }
+]

--- a/endpoints_data/protect-cameras.json
+++ b/endpoints_data/protect-cameras.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "camera-1",
+    "modelKey": "camera",
+    "state": "CONNECTED",
+    "name": "Front Door",
+    "type": "G4 Doorbell Pro",
+    "guid": "guid-camera-1",
+    "mac": "AABBCC223344",
+    "isMicEnabled": true,
+    "micVolume": 80,
+    "activePatrolSlot": null,
+    "videoMode": "default",
+    "hdrType": "normal",
+    "hasPackageCamera": true,
+    "osdSettings": {"isNameEnabled": true},
+    "ledSettings": {"isEnabled": true},
+    "lcdMessage": null,
+    "featureFlags": {"hasHdr": true},
+    "smartDetectSettings": {"objectTypes": ["person", "vehicle"]}
+  },
+  {
+    "id": "camera-2",
+    "modelKey": "camera",
+    "state": "DISCONNECTED",
+    "name": "Backyard",
+    "type": "G4 Pro",
+    "guid": "guid-camera-2",
+    "mac": "AABBCC223355",
+    "isMicEnabled": false,
+    "micVolume": 0,
+    "activePatrolSlot": null,
+    "videoMode": "highFps",
+    "hdrType": "auto",
+    "hasPackageCamera": false,
+    "osdSettings": {"isNameEnabled": false},
+    "ledSettings": {"isEnabled": false},
+    "lcdMessage": null,
+    "featureFlags": {"hasHdr": false},
+    "smartDetectSettings": {"objectTypes": []}
+  }
+]

--- a/endpoints_data/protect-lights.json
+++ b/endpoints_data/protect-lights.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "light-1",
+    "modelKey": "light",
+    "state": "CONNECTED",
+    "name": "Driveway Light",
+    "type": "Floodlight",
+    "guid": "guid-light-1",
+    "mac": "AABBCC334455",
+    "isDark": true,
+    "isLightOn": true,
+    "isLightForceEnabled": false,
+    "isPirMotionDetected": true,
+    "lastMotion": 1734000600000,
+    "camera": "camera-1",
+    "lightDeviceSettings": {
+      "isIndicatorEnabled": true,
+      "pirDuration": 15000,
+      "pirSensitivity": 50,
+      "ledLevel": 3
+    },
+    "lightModeSettings": {"mode": "motion"}
+  }
+]

--- a/endpoints_data/protect-link-stations.json
+++ b/endpoints_data/protect-link-stations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "linkstation-1",
+    "modelKey": "linkStation",
+    "state": "CONNECTED",
+    "name": "SuperLink Gateway",
+    "type": "SuperLink",
+    "guid": "guid-linkstation-1",
+    "mac": "AABBCC445566",
+    "isAlarmHub": true,
+    "lastEvent": 1734000700000,
+    "alarmHub": {
+      "armed": true,
+      "battery": {
+        "charging": true,
+        "connection": "wired",
+        "voltage": 13.2,
+        "batteryStatus": "ok"
+      },
+      "cover": {
+        "distance": 3.5,
+        "status": "closed"
+      },
+      "inputPower": {
+        "bt": 12.1,
+        "typ1": null,
+        "typ2": null
+      },
+      "buckboost": {"status": "ok"},
+      "connector": {"type": "usb-c"},
+      "currentMeterChannelStatus": {},
+      "currentMeterStatus": {},
+      "poeout": {"enabled": true},
+      "powerMeter": {},
+      "output": {},
+      "input": {},
+      "inputTerminalStatus": {},
+      "outputTerminalStatus": {},
+      "emergencyTerminalStatus": {},
+      "auxiliaryPowerTerminalStatus": {}
+    },
+    "ledSettings": {"isEnabled": true}
+  },
+  {
+    "id": "linkstation-2",
+    "modelKey": "linkStation",
+    "state": "CONNECTING",
+    "name": "Shed LinkStation",
+    "type": "LinkStation",
+    "guid": "guid-linkstation-2",
+    "mac": "AABBCC445577",
+    "isAlarmHub": false,
+    "lastEvent": null,
+    "alarmHub": null,
+    "ledSettings": null
+  }
+]

--- a/endpoints_data/protect-meta-info.json
+++ b/endpoints_data/protect-meta-info.json
@@ -1,0 +1,3 @@
+{
+  "applicationVersion": "5.1.113"
+}

--- a/endpoints_data/protect-nvrs.json
+++ b/endpoints_data/protect-nvrs.json
@@ -1,0 +1,20 @@
+{
+  "id": "nvr-1",
+  "modelKey": "nvr",
+  "state": "CONNECTED",
+  "name": "Home NVR",
+  "type": "UNVR",
+  "guid": "guid-nvr-1",
+  "mac": "AABBCC556677",
+  "armMode": {
+    "status": "armed",
+    "armProfileId": "profile-1",
+    "armedAt": 1734000800000,
+    "willBeArmedAt": null,
+    "breachDetectedAt": null,
+    "breachEventCount": 0,
+    "breachTriggerEventId": "",
+    "breachEventId": ""
+  },
+  "doorbellSettings": {"defaultMessage": "Be right there!"}
+}

--- a/endpoints_data/protect-sensors.json
+++ b/endpoints_data/protect-sensors.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "sensor-1",
+    "modelKey": "sensor",
+    "state": "CONNECTED",
+    "name": "Garage Door",
+    "type": "AI Sensor",
+    "guid": "guid-sensor-1",
+    "mac": "AABBCC112233",
+    "mountType": "door",
+    "batteryStatus": {
+      "percentage": 87,
+      "isLow": false
+    },
+    "featureFlags": {
+      "temperature": {"channelCount": 1},
+      "humidity": {"channelCount": 1},
+      "light": {"channelCount": 1},
+      "motion": {"channelCount": 1},
+      "waterLeak": null,
+      "open": {"channelCount": 1},
+      "tamper": {"channelCount": 1},
+      "smoke": null
+    },
+    "stats": {
+      "light": {"value": 123.4, "status": "neutral"},
+      "humidity": {"value": 41.2, "status": "safe"},
+      "temperature": {"value": 21.5, "status": "safe"}
+    },
+    "lightSettings": {"isEnabled": true, "margin": 2, "lowThreshold": null, "highThreshold": 500},
+    "humiditySettings": {"isEnabled": true, "margin": 2, "lowThreshold": 20, "highThreshold": 70},
+    "temperatureSettings": {"isEnabled": true, "margin": 1, "lowThreshold": 10, "highThreshold": 30},
+    "isOpened": false,
+    "openStatusChangedAt": 1734000000000,
+    "isMotionDetected": false,
+    "motionDetectedAt": null,
+    "motionSettings": {"isEnabled": true, "sensitivity": 50, "sensitivityWhenArmed": 75},
+    "scheduleMode": "always",
+    "armProfileIds": ["profile-1"],
+    "alarmTriggeredAt": null,
+    "leakDetectedAt": null,
+    "externalLeakDetectedAt": null,
+    "tamperingDetectedAt": null,
+    "wirelessConnectionState": {
+      "signalState": {"signalQuality": 5, "signalStrength": -55},
+      "batteryStatus": {"percentage": 87, "isLow": false},
+      "bridge": "bridge-1"
+    },
+    "glassBreakSettings": {"isEnabled": false}
+  },
+  {
+    "id": "sensor-2",
+    "modelKey": "sensor",
+    "state": "DISCONNECTED",
+    "name": "Shed Leak",
+    "type": "AI Sensor",
+    "guid": "guid-sensor-2",
+    "mac": "AABBCC112244",
+    "mountType": "leak",
+    "batteryStatus": {
+      "percentage": null,
+      "isLow": false
+    },
+    "featureFlags": {
+      "temperature": null,
+      "humidity": null,
+      "light": null,
+      "motion": null,
+      "waterLeak": {"channelCount": 1},
+      "open": null,
+      "tamper": {"channelCount": 1},
+      "smoke": null
+    },
+    "stats": {
+      "light": null,
+      "humidity": null,
+      "temperature": null
+    },
+    "lightSettings": null,
+    "humiditySettings": null,
+    "temperatureSettings": null,
+    "isOpened": false,
+    "openStatusChangedAt": null,
+    "isMotionDetected": false,
+    "motionDetectedAt": null,
+    "motionSettings": null,
+    "scheduleMode": "when_armed",
+    "armProfileIds": [],
+    "alarmTriggeredAt": null,
+    "leakDetectedAt": 1734000500000,
+    "externalLeakDetectedAt": null,
+    "tamperingDetectedAt": null,
+    "wirelessConnectionState": {
+      "signalState": {"signalQuality": null, "signalStrength": null},
+      "batteryStatus": {"percentage": null, "isLow": false},
+      "bridge": "bridge-1"
+    },
+    "glassBreakSettings": null
+  }
+]

--- a/events_test.go
+++ b/events_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestIPGeoUnmarshalJSON(t *testing.T) {

--- a/firewall_zones_test.go
+++ b/firewall_zones_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestFirewallZone(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/unpoller/unifi/v5
+module github.com/unpoller/unifi/v6
 
 go 1.25.5
 

--- a/hotspot_vouchers_test.go
+++ b/hotspot_vouchers_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestHotspotVoucher(t *testing.T) {

--- a/integration_devices_test.go
+++ b/integration_devices_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestIntegrationDeviceStats(t *testing.T) {

--- a/integration_networks_test.go
+++ b/integration_networks_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestIntegrationNetwork(t *testing.T) {

--- a/integration_wans_test.go
+++ b/integration_wans_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestIntegrationWAN(t *testing.T) {

--- a/main/main.go
+++ b/main/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func GetEnvString(key, fallback string) string {

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 type MockUnifi struct {

--- a/mocks/mock_client_test.go
+++ b/mocks/mock_client_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5/mocks"
+	"github.com/unpoller/unifi/v6/mocks"
 )
 
 func TestMockUnifiClient(t *testing.T) {

--- a/mocks/mock_server.go
+++ b/mocks/mock_server.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 type MockHTTPTestServer struct {

--- a/pdu_test.go
+++ b/pdu_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 //go:embed examples/pdu.json

--- a/pending_devices_test.go
+++ b/pending_devices_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestPendingDevice(t *testing.T) {

--- a/port_forwards_test.go
+++ b/port_forwards_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestPortForwardStruct(t *testing.T) {

--- a/protect.go
+++ b/protect.go
@@ -1,0 +1,529 @@
+package unifi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Protect device support is built on Ubiquiti's official, documented Protect Integration
+// API (https://developer.ui.com/protect/), not the private bootstrap API. See
+// unpoller/unpoller#1015. Getters are deliberately not part of the UnifiClient interface,
+// matching the UNAS convention in unas.go: a Network-only console answers none of them, and
+// adding them to the interface would force matching methods onto mocks.MockUnifi for no
+// benefit, since inputunifi holds a concrete *Unifi rather than the interface.
+
+// protectEndpointCount is the number of endpoints GetProtectDevices polls: sensors, cameras,
+// lights, bridges, link-stations, and the NVR. /v1/meta/info is a separate reachability
+// probe (used by callers to detect "Protect not installed" before polling) and is not part
+// of this tally.
+const protectEndpointCount = 6
+
+// ProtectStateValue maps a Protect device connection state to a numeric gauge value, so every
+// output plugin agrees on the mapping instead of each inventing its own. Keep the raw state
+// string as a label/tag alongside the number: the number is for alerting, the string for
+// debugging. Unknown states are -1, never 0 -- 0 means DISCONNECTED.
+func ProtectStateValue(state string) float64 {
+	switch state {
+	case "CONNECTED":
+		return 2
+	case "CONNECTING":
+		return 1
+	case "DISCONNECTED":
+		return 0
+	default:
+		return -1
+	}
+}
+
+// ProtectMetaInfo holds the Protect application version, from /v1/meta/info. It is the
+// cheapest available endpoint and the recommended probe for "is Protect installed and is
+// this key valid" before polling the rest.
+type ProtectMetaInfo struct {
+	ApplicationVersion string `json:"applicationVersion"`
+}
+
+// ProtectDeviceIdentity holds the fields common to every Protect device.
+type ProtectDeviceIdentity struct {
+	ID       string `json:"id"`
+	ModelKey string `json:"modelKey"`
+	State    string `json:"state"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	GUID     string `json:"guid"`
+	MAC      string `json:"mac"`
+}
+
+// ProtectBatteryStatus holds a device's battery percentage and low-battery flag.
+// Percentage is nullable in the spec: a device with no battery reports Percentage == nil,
+// which must be skipped by callers, never treated as 0.
+type ProtectBatteryStatus struct {
+	Percentage *float64 `json:"percentage"`
+	IsLow      bool     `json:"isLow"`
+}
+
+// ProtectSignalState holds a wireless device's signal quality and strength.
+type ProtectSignalState struct {
+	SignalQuality  *float64 `json:"signalQuality"`
+	SignalStrength *float64 `json:"signalStrength"`
+}
+
+// ProtectWirelessConnectionState holds a wireless sensor's link to its bridge.
+type ProtectWirelessConnectionState struct {
+	SignalState   *ProtectSignalState   `json:"signalState"`
+	BatteryStatus *ProtectBatteryStatus `json:"batteryStatus"`
+	Bridge        string                `json:"bridge"`
+}
+
+// ProtectSensorChannelFlag reports whether a sensor supports a given measurement and, if so,
+// on how many channels.
+type ProtectSensorChannelFlag struct {
+	ChannelCount int `json:"channelCount"`
+}
+
+// ProtectSensorFeatureFlags reports which measurements a sensor supports.
+type ProtectSensorFeatureFlags struct {
+	Temperature *ProtectSensorChannelFlag `json:"temperature"`
+	Humidity    *ProtectSensorChannelFlag `json:"humidity"`
+	Light       *ProtectSensorChannelFlag `json:"light"`
+	Motion      *ProtectSensorChannelFlag `json:"motion"`
+	WaterLeak   *ProtectSensorChannelFlag `json:"waterLeak"`
+	Open        *ProtectSensorChannelFlag `json:"open"`
+	Tamper      *ProtectSensorChannelFlag `json:"tamper"`
+	Smoke       *ProtectSensorChannelFlag `json:"smoke"`
+}
+
+// ProtectSensorStatValue holds one sensor reading. Value is nullable: a sensor without this
+// feature, or one that hasn't reported yet, sends null and must be skipped, not zeroed.
+type ProtectSensorStatValue struct {
+	Value  *float64 `json:"value"`
+	Status string   `json:"status"` // neutral, low, safe, high, unknown
+}
+
+// ProtectSensorStats holds a sensor's current readings.
+type ProtectSensorStats struct {
+	Light       *ProtectSensorStatValue `json:"light"`
+	Humidity    *ProtectSensorStatValue `json:"humidity"`
+	Temperature *ProtectSensorStatValue `json:"temperature"`
+}
+
+// ProtectSensorThresholdSettings holds the alerting configuration for one sensor measurement.
+type ProtectSensorThresholdSettings struct {
+	IsEnabled     bool     `json:"isEnabled"`
+	Margin        *float64 `json:"margin"`
+	LowThreshold  *float64 `json:"lowThreshold"`
+	HighThreshold *float64 `json:"highThreshold"`
+}
+
+// ProtectSensorMotionSettings holds a sensor's motion-detection configuration.
+type ProtectSensorMotionSettings struct {
+	IsEnabled            bool `json:"isEnabled"`
+	Sensitivity          int  `json:"sensitivity"`
+	SensitivityWhenArmed int  `json:"sensitivityWhenArmed"`
+}
+
+// ProtectSensor represents a Protect sensor, including SuperLink sensors (unpoller/unpoller#1015).
+// API Path: /proxy/protect/integration/v1/sensors
+type ProtectSensor struct {
+	ProtectDeviceIdentity
+
+	MountType string `json:"mountType"` // door, window, garage, leak, none
+
+	BatteryStatus *ProtectBatteryStatus      `json:"batteryStatus"`
+	FeatureFlags  *ProtectSensorFeatureFlags `json:"featureFlags"`
+	Stats         *ProtectSensorStats        `json:"stats"`
+
+	LightSettings       *ProtectSensorThresholdSettings `json:"lightSettings"`
+	HumiditySettings    *ProtectSensorThresholdSettings `json:"humiditySettings"`
+	TemperatureSettings *ProtectSensorThresholdSettings `json:"temperatureSettings"`
+
+	IsOpened            bool   `json:"isOpened"`
+	OpenStatusChangedAt *int64 `json:"openStatusChangedAt"`
+
+	IsMotionDetected bool                         `json:"isMotionDetected"`
+	MotionDetectedAt *int64                       `json:"motionDetectedAt"`
+	MotionSettings   *ProtectSensorMotionSettings `json:"motionSettings"`
+
+	ScheduleMode  string   `json:"scheduleMode"` // always, when_armed
+	ArmProfileIDs []string `json:"armProfileIds"`
+
+	AlarmTriggeredAt       *int64 `json:"alarmTriggeredAt"`
+	LeakDetectedAt         *int64 `json:"leakDetectedAt"`
+	ExternalLeakDetectedAt *int64 `json:"externalLeakDetectedAt"`
+	TamperingDetectedAt    *int64 `json:"tamperingDetectedAt"`
+
+	WirelessConnectionState *ProtectWirelessConnectionState `json:"wirelessConnectionState"`
+
+	// GlassBreakSettings has no documented shape; kept raw for diagnosis, per the UNAS
+	// convention (unas.go).
+	GlassBreakSettings json.RawMessage `fake:"skip" json:"glassBreakSettings"`
+}
+
+// ProtectCamera represents a Protect camera. Only state is metric-shaped in v1; the rest is
+// configuration, per the scope decision in the Protect device metrics plan.
+// API Path: /proxy/protect/integration/v1/cameras
+type ProtectCamera struct {
+	ProtectDeviceIdentity
+
+	IsMicEnabled     bool   `json:"isMicEnabled"`
+	MicVolume        int    `json:"micVolume"`
+	ActivePatrolSlot *int   `json:"activePatrolSlot"`
+	VideoMode        string `json:"videoMode"`
+	HdrType          string `json:"hdrType"`
+	HasPackageCamera bool   `json:"hasPackageCamera"`
+
+	// The following are documented as objects but their detailed shape is not; kept raw for
+	// diagnosis rather than invented, per the UNAS convention (unas.go).
+	OSDSettings         json.RawMessage `fake:"skip" json:"osdSettings"`
+	LEDSettings         json.RawMessage `fake:"skip" json:"ledSettings"`
+	LCDMessage          json.RawMessage `fake:"skip" json:"lcdMessage"`
+	FeatureFlags        json.RawMessage `fake:"skip" json:"featureFlags"`
+	SmartDetectSettings json.RawMessage `fake:"skip" json:"smartDetectSettings"`
+}
+
+// ProtectLightDeviceSettings holds a light's physical configuration.
+type ProtectLightDeviceSettings struct {
+	IsIndicatorEnabled bool `json:"isIndicatorEnabled"`
+	PIRDuration        int  `json:"pirDuration"`
+	PIRSensitivity     int  `json:"pirSensitivity"`
+	LEDLevel           int  `json:"ledLevel"`
+}
+
+// ProtectLight represents a Protect floodlight.
+// API Path: /proxy/protect/integration/v1/lights
+type ProtectLight struct {
+	ProtectDeviceIdentity
+
+	IsDark              bool   `json:"isDark"`
+	IsLightOn           bool   `json:"isLightOn"`
+	IsLightForceEnabled bool   `json:"isLightForceEnabled"`
+	IsPirMotionDetected bool   `json:"isPirMotionDetected"`
+	LastMotion          *int64 `json:"lastMotion"`
+	Camera              string `json:"camera"` // ID of the paired camera, if any
+
+	LightDeviceSettings *ProtectLightDeviceSettings `json:"lightDeviceSettings"`
+
+	// LightModeSettings is documented as an object but its detailed shape is not; kept raw
+	// for diagnosis rather than invented, per the UNAS convention (unas.go).
+	LightModeSettings json.RawMessage `fake:"skip" json:"lightModeSettings"`
+}
+
+// ProtectBridge represents a Protect wireless bridge, such as a SuperLink Gateway.
+// API Path: /proxy/protect/integration/v1/bridges
+type ProtectBridge struct {
+	ProtectDeviceIdentity
+
+	Platform   string   `json:"platform"`
+	Clients    []string `json:"clients"`
+	MaxClients int      `json:"maxClients"`
+}
+
+// ProtectLinkStationCover holds a link station's tamper-cover state.
+type ProtectLinkStationCover struct {
+	Distance *float64 `json:"distance"`
+	Status   string   `json:"status"`
+}
+
+// ProtectLinkStationBattery holds a link station's (alarm hub's) battery state.
+type ProtectLinkStationBattery struct {
+	Charging      bool     `json:"charging"`
+	Connection    string   `json:"connection"`
+	Voltage       *float64 `json:"voltage"`
+	BatteryStatus string   `json:"batteryStatus"` // ok, low, critical
+}
+
+// ProtectInputPower holds a link station's input power readings, by input type.
+type ProtectInputPower struct {
+	BT   *float64 `json:"bt"`
+	Typ1 *float64 `json:"typ1"`
+	Typ2 *float64 `json:"typ2"`
+}
+
+// ProtectAlarmHub holds the metrics exposed by a link station acting as an alarm hub
+// (isAlarmHub == true), such as a SuperLink Gateway.
+type ProtectAlarmHub struct {
+	Armed      bool                       `json:"armed"`
+	Battery    *ProtectLinkStationBattery `json:"battery"`
+	Cover      *ProtectLinkStationCover   `json:"cover"`
+	InputPower *ProtectInputPower         `json:"inputPower"`
+
+	// The following are documented as objects but their detailed shape is not; kept raw for
+	// diagnosis rather than invented, per the UNAS convention (unas.go).
+	BuckBoost                    json.RawMessage `fake:"skip" json:"buckboost"`
+	Connector                    json.RawMessage `fake:"skip" json:"connector"`
+	CurrentMeterChannelStatus    json.RawMessage `fake:"skip" json:"currentMeterChannelStatus"`
+	CurrentMeterStatus           json.RawMessage `fake:"skip" json:"currentMeterStatus"`
+	Poeout                       json.RawMessage `fake:"skip" json:"poeout"`
+	PowerMeter                   json.RawMessage `fake:"skip" json:"powerMeter"`
+	Output                       json.RawMessage `fake:"skip" json:"output"`
+	Input                        json.RawMessage `fake:"skip" json:"input"`
+	InputTerminalStatus          json.RawMessage `fake:"skip" json:"inputTerminalStatus"`
+	OutputTerminalStatus         json.RawMessage `fake:"skip" json:"outputTerminalStatus"`
+	EmergencyTerminalStatus      json.RawMessage `fake:"skip" json:"emergencyTerminalStatus"`
+	AuxiliaryPowerTerminalStatus json.RawMessage `fake:"skip" json:"auxiliaryPowerTerminalStatus"`
+}
+
+// ProtectLinkStation represents a Protect link station. /v1/alarm-hubs returns the same
+// schema filtered to IsAlarmHub == true; GetProtectLinkStations covers both and the
+// alarm-hubs endpoint is deliberately not polled, to avoid double-counting.
+// API Path: /proxy/protect/integration/v1/link-stations
+type ProtectLinkStation struct {
+	ProtectDeviceIdentity
+
+	IsAlarmHub bool             `json:"isAlarmHub"`
+	LastEvent  *int64           `json:"lastEvent"`
+	AlarmHub   *ProtectAlarmHub `json:"alarmHub"`
+
+	// LedSettings is documented as an object but its detailed shape is not; kept raw for
+	// diagnosis rather than invented, per the UNAS convention (unas.go).
+	LedSettings json.RawMessage `fake:"skip" json:"ledSettings"`
+}
+
+// ProtectArmMode holds an NVR's alarm-arming state.
+type ProtectArmMode struct {
+	Status               string `json:"status"` // arming, armed, breach, disabled
+	ArmProfileID         string `json:"armProfileId"`
+	ArmedAt              *int64 `json:"armedAt"`
+	WillBeArmedAt        *int64 `json:"willBeArmedAt"`
+	BreachDetectedAt     *int64 `json:"breachDetectedAt"`
+	BreachEventCount     int    `json:"breachEventCount"`
+	BreachTriggerEventID string `json:"breachTriggerEventId"`
+	BreachEventID        string `json:"breachEventId"`
+}
+
+// ProtectNVR represents the NVR console itself. Only ArmMode is metric-shaped in v1; the
+// rest is configuration. GET /v1/nvrs returns a single object, not an array.
+// API Path: /proxy/protect/integration/v1/nvrs
+type ProtectNVR struct {
+	ProtectDeviceIdentity
+
+	ArmMode *ProtectArmMode `json:"armMode"`
+
+	// DoorbellSettings is documented as an object but its detailed shape is not; kept raw
+	// for diagnosis rather than invented, per the UNAS convention (unas.go).
+	DoorbellSettings json.RawMessage `fake:"skip" json:"doorbellSettings"`
+}
+
+// ProtectDevices is the aggregate of every polled Protect endpoint for one console.
+// Any member may be nil (or empty, for slices) if that endpoint failed; check before use.
+type ProtectDevices struct {
+	SourceName string
+	// Version is not populated by GetProtectDevices -- adding a meta/info call here would
+	// make it a 7th polled endpoint and break protectEndpointCount accounting. Callers that
+	// already probe /v1/meta/info for reachability (see ProtectMetaInfo) should set this
+	// themselves from that result.
+	Version string
+	NVR     *ProtectNVR
+
+	Sensors      []*ProtectSensor      `fakesize:"5"`
+	Cameras      []*ProtectCamera      `fakesize:"5"`
+	Lights       []*ProtectLight       `fakesize:"5"`
+	Bridges      []*ProtectBridge      `fakesize:"5"`
+	LinkStations []*ProtectLinkStation `fakesize:"5"`
+}
+
+// GetProtectMetaInfo returns the Protect application version. This is the cheapest
+// available endpoint and the recommended probe for "is Protect installed and is this key
+// valid" before polling the rest.
+func (u *Unifi) GetProtectMetaInfo() (*ProtectMetaInfo, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	u.DebugLog("Polling Protect Integration/v1 for meta info")
+
+	info := &ProtectMetaInfo{}
+
+	if err := u.GetData(APIProtectMetaInfoPath, info); err != nil {
+		return nil, fmt.Errorf("fetching Protect meta info: %w", err)
+	}
+
+	return info, nil
+}
+
+// getProtectList fetches a Protect Integration/v1 list endpoint. Unlike the Network
+// Integration/v1 API (see getIntegrationList in integration.go), Protect list endpoints
+// return a bare JSON array with no pagination envelope.
+func getProtectList[T any](u *Unifi, path string) ([]*T, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	var items []T
+
+	if err := u.GetData(path, &items); err != nil {
+		return nil, err
+	}
+
+	result := make([]*T, len(items))
+
+	for i := range items {
+		result[i] = &items[i]
+	}
+
+	return result, nil
+}
+
+// GetProtectSensors returns all Protect sensors, including SuperLink sensors.
+func (u *Unifi) GetProtectSensors() ([]*ProtectSensor, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	u.DebugLog("Polling Protect Integration/v1 for sensors")
+
+	sensors, err := getProtectList[ProtectSensor](u, APIProtectSensorsPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Protect sensors: %w", err)
+	}
+
+	return sensors, nil
+}
+
+// GetProtectCameras returns all Protect cameras.
+func (u *Unifi) GetProtectCameras() ([]*ProtectCamera, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	u.DebugLog("Polling Protect Integration/v1 for cameras")
+
+	cameras, err := getProtectList[ProtectCamera](u, APIProtectCamerasPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Protect cameras: %w", err)
+	}
+
+	return cameras, nil
+}
+
+// GetProtectLights returns all Protect lights.
+func (u *Unifi) GetProtectLights() ([]*ProtectLight, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	u.DebugLog("Polling Protect Integration/v1 for lights")
+
+	lights, err := getProtectList[ProtectLight](u, APIProtectLightsPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Protect lights: %w", err)
+	}
+
+	return lights, nil
+}
+
+// GetProtectBridges returns all Protect wireless bridges, such as SuperLink Gateways.
+func (u *Unifi) GetProtectBridges() ([]*ProtectBridge, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	u.DebugLog("Polling Protect Integration/v1 for bridges")
+
+	bridges, err := getProtectList[ProtectBridge](u, APIProtectBridgesPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Protect bridges: %w", err)
+	}
+
+	return bridges, nil
+}
+
+// GetProtectLinkStations returns all Protect link stations, including alarm hubs.
+// /v1/alarm-hubs is deliberately not polled: it returns the same schema filtered to
+// IsAlarmHub == true, and polling both would double-count every alarm hub.
+func (u *Unifi) GetProtectLinkStations() ([]*ProtectLinkStation, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	u.DebugLog("Polling Protect Integration/v1 for link stations")
+
+	stations, err := getProtectList[ProtectLinkStation](u, APIProtectLinkStationsPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Protect link stations: %w", err)
+	}
+
+	return stations, nil
+}
+
+// GetProtectNVR returns the NVR console itself. GET /v1/nvrs returns a single object, not
+// an array -- easy to get wrong.
+func (u *Unifi) GetProtectNVR() (*ProtectNVR, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	u.DebugLog("Polling Protect Integration/v1 for NVR")
+
+	nvr := &ProtectNVR{}
+
+	if err := u.GetData(APIProtectNVRPath, nvr); err != nil {
+		return nil, fmt.Errorf("fetching Protect NVR: %w", err)
+	}
+
+	return nvr, nil
+}
+
+// GetProtectDevices polls every Protect endpoint and returns the aggregate.
+//
+// Every endpoint is attempted even if an earlier one failed, so a console that exposes only
+// some of them still reports what it has. A partial failure is deliberately NOT an error:
+// the failing endpoints are logged to ErrorLog and their fields left nil/empty, because the
+// natural `if err != nil { return }` at the call site would otherwise drop every metric
+// whenever one endpoint 404s -- and a Protect estate with no lights or no link-stations is
+// the normal case, not an error. An error is returned only when nothing at all could be
+// fetched, and then the device is nil. This mirrors GetUNASDevice in unas.go.
+func (u *Unifi) GetProtectDevices() (*ProtectDevices, error) {
+	if u == nil {
+		return nil, ErrNilUnifi
+	}
+
+	device := &ProtectDevices{SourceName: u.URL}
+	errs := []error{}
+
+	if sensors, err := u.GetProtectSensors(); err != nil {
+		errs = append(errs, err)
+	} else {
+		device.Sensors = sensors
+	}
+
+	if cameras, err := u.GetProtectCameras(); err != nil {
+		errs = append(errs, err)
+	} else {
+		device.Cameras = cameras
+	}
+
+	if lights, err := u.GetProtectLights(); err != nil {
+		errs = append(errs, err)
+	} else {
+		device.Lights = lights
+	}
+
+	if bridges, err := u.GetProtectBridges(); err != nil {
+		errs = append(errs, err)
+	} else {
+		device.Bridges = bridges
+	}
+
+	if stations, err := u.GetProtectLinkStations(); err != nil {
+		errs = append(errs, err)
+	} else {
+		device.LinkStations = stations
+	}
+
+	if nvr, err := u.GetProtectNVR(); err != nil {
+		errs = append(errs, err)
+	} else {
+		device.NVR = nvr
+	}
+
+	if len(errs) == protectEndpointCount {
+		return nil, errors.Join(errs...)
+	}
+
+	for _, err := range errs {
+		u.ErrorLog("Protect %s: %v", u.URL, err)
+	}
+
+	return device, nil
+}

--- a/protect.go
+++ b/protect.go
@@ -55,17 +55,18 @@ type ProtectDeviceIdentity struct {
 }
 
 // ProtectBatteryStatus holds a device's battery percentage and low-battery flag.
-// Percentage is nullable in the spec: a device with no battery reports Percentage == nil,
-// which must be skipped by callers, never treated as 0.
+// Percentage is nullable in the spec (a device with no battery reports a JSON null); this
+// uses FlexFloat, consistent with the rest of the library, which reads that null as 0 --
+// a deliberate choice of uniform typing over preserving the null/zero distinction.
 type ProtectBatteryStatus struct {
-	Percentage *float64 `json:"percentage"`
-	IsLow      bool     `json:"isLow"`
+	Percentage FlexFloat `json:"percentage"`
+	IsLow      FlexBool  `json:"isLow"`
 }
 
 // ProtectSignalState holds a wireless device's signal quality and strength.
 type ProtectSignalState struct {
-	SignalQuality  *float64 `json:"signalQuality"`
-	SignalStrength *float64 `json:"signalStrength"`
+	SignalQuality  FlexFloat `json:"signalQuality"`
+	SignalStrength FlexFloat `json:"signalStrength"`
 }
 
 // ProtectWirelessConnectionState holds a wireless sensor's link to its bridge.
@@ -78,7 +79,7 @@ type ProtectWirelessConnectionState struct {
 // ProtectSensorChannelFlag reports whether a sensor supports a given measurement and, if so,
 // on how many channels.
 type ProtectSensorChannelFlag struct {
-	ChannelCount int `json:"channelCount"`
+	ChannelCount FlexInt `json:"channelCount"`
 }
 
 // ProtectSensorFeatureFlags reports which measurements a sensor supports.
@@ -93,11 +94,13 @@ type ProtectSensorFeatureFlags struct {
 	Smoke       *ProtectSensorChannelFlag `json:"smoke"`
 }
 
-// ProtectSensorStatValue holds one sensor reading. Value is nullable: a sensor without this
-// feature, or one that hasn't reported yet, sends null and must be skipped, not zeroed.
+// ProtectSensorStatValue holds one sensor reading. Value is nullable in the spec (a sensor
+// without this feature, or one that hasn't reported yet, sends null); this uses FlexFloat,
+// consistent with the rest of the library, which reads that null as 0 -- a deliberate choice
+// of uniform typing over preserving the null/zero distinction.
 type ProtectSensorStatValue struct {
-	Value  *float64 `json:"value"`
-	Status string   `json:"status"` // neutral, low, safe, high, unknown
+	Value  FlexFloat `json:"value"`
+	Status string    `json:"status"` // neutral, low, safe, high, unknown
 }
 
 // ProtectSensorStats holds a sensor's current readings.
@@ -109,17 +112,17 @@ type ProtectSensorStats struct {
 
 // ProtectSensorThresholdSettings holds the alerting configuration for one sensor measurement.
 type ProtectSensorThresholdSettings struct {
-	IsEnabled     bool     `json:"isEnabled"`
-	Margin        *float64 `json:"margin"`
-	LowThreshold  *float64 `json:"lowThreshold"`
-	HighThreshold *float64 `json:"highThreshold"`
+	IsEnabled     FlexBool  `json:"isEnabled"`
+	Margin        FlexFloat `json:"margin"`
+	LowThreshold  FlexFloat `json:"lowThreshold"`
+	HighThreshold FlexFloat `json:"highThreshold"`
 }
 
 // ProtectSensorMotionSettings holds a sensor's motion-detection configuration.
 type ProtectSensorMotionSettings struct {
-	IsEnabled            bool `json:"isEnabled"`
-	Sensitivity          int  `json:"sensitivity"`
-	SensitivityWhenArmed int  `json:"sensitivityWhenArmed"`
+	IsEnabled            FlexBool `json:"isEnabled"`
+	Sensitivity          FlexInt  `json:"sensitivity"`
+	SensitivityWhenArmed FlexInt  `json:"sensitivityWhenArmed"`
 }
 
 // ProtectSensor represents a Protect sensor, including SuperLink sensors (unpoller/unpoller#1015).
@@ -137,20 +140,20 @@ type ProtectSensor struct {
 	HumiditySettings    *ProtectSensorThresholdSettings `json:"humiditySettings"`
 	TemperatureSettings *ProtectSensorThresholdSettings `json:"temperatureSettings"`
 
-	IsOpened            bool   `json:"isOpened"`
-	OpenStatusChangedAt *int64 `json:"openStatusChangedAt"`
+	IsOpened            FlexBool `json:"isOpened"`
+	OpenStatusChangedAt FlexInt  `json:"openStatusChangedAt"`
 
-	IsMotionDetected bool                         `json:"isMotionDetected"`
-	MotionDetectedAt *int64                       `json:"motionDetectedAt"`
+	IsMotionDetected FlexBool                     `json:"isMotionDetected"`
+	MotionDetectedAt FlexInt                      `json:"motionDetectedAt"`
 	MotionSettings   *ProtectSensorMotionSettings `json:"motionSettings"`
 
 	ScheduleMode  string   `json:"scheduleMode"` // always, when_armed
 	ArmProfileIDs []string `json:"armProfileIds"`
 
-	AlarmTriggeredAt       *int64 `json:"alarmTriggeredAt"`
-	LeakDetectedAt         *int64 `json:"leakDetectedAt"`
-	ExternalLeakDetectedAt *int64 `json:"externalLeakDetectedAt"`
-	TamperingDetectedAt    *int64 `json:"tamperingDetectedAt"`
+	AlarmTriggeredAt       FlexInt `json:"alarmTriggeredAt"`
+	LeakDetectedAt         FlexInt `json:"leakDetectedAt"`
+	ExternalLeakDetectedAt FlexInt `json:"externalLeakDetectedAt"`
+	TamperingDetectedAt    FlexInt `json:"tamperingDetectedAt"`
 
 	WirelessConnectionState *ProtectWirelessConnectionState `json:"wirelessConnectionState"`
 
@@ -165,12 +168,12 @@ type ProtectSensor struct {
 type ProtectCamera struct {
 	ProtectDeviceIdentity
 
-	IsMicEnabled     bool   `json:"isMicEnabled"`
-	MicVolume        int    `json:"micVolume"`
-	ActivePatrolSlot *int   `json:"activePatrolSlot"`
-	VideoMode        string `json:"videoMode"`
-	HdrType          string `json:"hdrType"`
-	HasPackageCamera bool   `json:"hasPackageCamera"`
+	IsMicEnabled     FlexBool `json:"isMicEnabled"`
+	MicVolume        FlexInt  `json:"micVolume"`
+	ActivePatrolSlot FlexInt  `json:"activePatrolSlot"`
+	VideoMode        string   `json:"videoMode"`
+	HdrType          string   `json:"hdrType"`
+	HasPackageCamera FlexBool `json:"hasPackageCamera"`
 
 	// The following are documented as objects but their detailed shape is not; kept raw for
 	// diagnosis rather than invented, per the UNAS convention (unas.go).
@@ -183,10 +186,10 @@ type ProtectCamera struct {
 
 // ProtectLightDeviceSettings holds a light's physical configuration.
 type ProtectLightDeviceSettings struct {
-	IsIndicatorEnabled bool `json:"isIndicatorEnabled"`
-	PIRDuration        int  `json:"pirDuration"`
-	PIRSensitivity     int  `json:"pirSensitivity"`
-	LEDLevel           int  `json:"ledLevel"`
+	IsIndicatorEnabled FlexBool `json:"isIndicatorEnabled"`
+	PIRDuration        FlexInt  `json:"pirDuration"`
+	PIRSensitivity     FlexInt  `json:"pirSensitivity"`
+	LEDLevel           FlexInt  `json:"ledLevel"`
 }
 
 // ProtectLight represents a Protect floodlight.
@@ -194,12 +197,12 @@ type ProtectLightDeviceSettings struct {
 type ProtectLight struct {
 	ProtectDeviceIdentity
 
-	IsDark              bool   `json:"isDark"`
-	IsLightOn           bool   `json:"isLightOn"`
-	IsLightForceEnabled bool   `json:"isLightForceEnabled"`
-	IsPirMotionDetected bool   `json:"isPirMotionDetected"`
-	LastMotion          *int64 `json:"lastMotion"`
-	Camera              string `json:"camera"` // ID of the paired camera, if any
+	IsDark              FlexBool `json:"isDark"`
+	IsLightOn           FlexBool `json:"isLightOn"`
+	IsLightForceEnabled FlexBool `json:"isLightForceEnabled"`
+	IsPirMotionDetected FlexBool `json:"isPirMotionDetected"`
+	LastMotion          FlexInt  `json:"lastMotion"`
+	Camera              string   `json:"camera"` // ID of the paired camera, if any
 
 	LightDeviceSettings *ProtectLightDeviceSettings `json:"lightDeviceSettings"`
 
@@ -215,34 +218,34 @@ type ProtectBridge struct {
 
 	Platform   string   `json:"platform"`
 	Clients    []string `json:"clients"`
-	MaxClients int      `json:"maxClients"`
+	MaxClients FlexInt  `json:"maxClients"`
 }
 
 // ProtectLinkStationCover holds a link station's tamper-cover state.
 type ProtectLinkStationCover struct {
-	Distance *float64 `json:"distance"`
-	Status   string   `json:"status"`
+	Distance FlexFloat `json:"distance"`
+	Status   string    `json:"status"`
 }
 
 // ProtectLinkStationBattery holds a link station's (alarm hub's) battery state.
 type ProtectLinkStationBattery struct {
-	Charging      bool     `json:"charging"`
-	Connection    string   `json:"connection"`
-	Voltage       *float64 `json:"voltage"`
-	BatteryStatus string   `json:"batteryStatus"` // ok, low, critical
+	Charging      FlexBool  `json:"charging"`
+	Connection    string    `json:"connection"`
+	Voltage       FlexFloat `json:"voltage"`
+	BatteryStatus string    `json:"batteryStatus"` // ok, low, critical
 }
 
 // ProtectInputPower holds a link station's input power readings, by input type.
 type ProtectInputPower struct {
-	BT   *float64 `json:"bt"`
-	Typ1 *float64 `json:"typ1"`
-	Typ2 *float64 `json:"typ2"`
+	BT   FlexFloat `json:"bt"`
+	Typ1 FlexFloat `json:"typ1"`
+	Typ2 FlexFloat `json:"typ2"`
 }
 
 // ProtectAlarmHub holds the metrics exposed by a link station acting as an alarm hub
 // (isAlarmHub == true), such as a SuperLink Gateway.
 type ProtectAlarmHub struct {
-	Armed      bool                       `json:"armed"`
+	Armed      FlexBool                   `json:"armed"`
 	Battery    *ProtectLinkStationBattery `json:"battery"`
 	Cover      *ProtectLinkStationCover   `json:"cover"`
 	InputPower *ProtectInputPower         `json:"inputPower"`
@@ -270,8 +273,8 @@ type ProtectAlarmHub struct {
 type ProtectLinkStation struct {
 	ProtectDeviceIdentity
 
-	IsAlarmHub bool             `json:"isAlarmHub"`
-	LastEvent  *int64           `json:"lastEvent"`
+	IsAlarmHub FlexBool         `json:"isAlarmHub"`
+	LastEvent  FlexInt          `json:"lastEvent"`
 	AlarmHub   *ProtectAlarmHub `json:"alarmHub"`
 
 	// LedSettings is documented as an object but its detailed shape is not; kept raw for
@@ -281,14 +284,14 @@ type ProtectLinkStation struct {
 
 // ProtectArmMode holds an NVR's alarm-arming state.
 type ProtectArmMode struct {
-	Status               string `json:"status"` // arming, armed, breach, disabled
-	ArmProfileID         string `json:"armProfileId"`
-	ArmedAt              *int64 `json:"armedAt"`
-	WillBeArmedAt        *int64 `json:"willBeArmedAt"`
-	BreachDetectedAt     *int64 `json:"breachDetectedAt"`
-	BreachEventCount     int    `json:"breachEventCount"`
-	BreachTriggerEventID string `json:"breachTriggerEventId"`
-	BreachEventID        string `json:"breachEventId"`
+	Status               string  `json:"status"` // arming, armed, breach, disabled
+	ArmProfileID         string  `json:"armProfileId"`
+	ArmedAt              FlexInt `json:"armedAt"`
+	WillBeArmedAt        FlexInt `json:"willBeArmedAt"`
+	BreachDetectedAt     FlexInt `json:"breachDetectedAt"`
+	BreachEventCount     FlexInt `json:"breachEventCount"`
+	BreachTriggerEventID string  `json:"breachTriggerEventId"`
+	BreachEventID        string  `json:"breachEventId"`
 }
 
 // ProtectNVR represents the NVR console itself. Only ArmMode is metric-shaped in v1; the

--- a/protect_test.go
+++ b/protect_test.go
@@ -1,0 +1,430 @@
+package unifi // nolint: testpackage
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// protectFixtures maps each Protect API path to the file serving its response.
+var protectFixtures = map[string]string{
+	APIProtectMetaInfoPath:     "endpoints_data/protect-meta-info.json",
+	APIProtectSensorsPath:      "endpoints_data/protect-sensors.json",
+	APIProtectCamerasPath:      "endpoints_data/protect-cameras.json",
+	APIProtectLightsPath:       "endpoints_data/protect-lights.json",
+	APIProtectBridgesPath:      "endpoints_data/protect-bridges.json",
+	APIProtectLinkStationsPath: "endpoints_data/protect-link-stations.json",
+	APIProtectNVRPath:          "endpoints_data/protect-nvrs.json",
+}
+
+// newProtectTestClient returns a *Unifi pointed at a server that answers the Protect paths
+// from fixtures. Paths listed in fail are answered with a 500 instead. The returned slice
+// records the paths and X-API-Key headers the client actually requested, in order.
+func newProtectTestClient(t *testing.T, fail ...string) (*Unifi, *[]string) {
+	t.Helper()
+
+	failed := make(map[string]bool, len(fail))
+	for _, p := range fail {
+		failed[p] = true
+	}
+
+	requested := &[]string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requested = append(*requested, r.URL.Path)
+
+		if failed[r.URL.Path] {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		file, ok := protectFixtures[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		body, err := os.ReadFile(file)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, ProtectAPIKey: "protect-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    true,
+	}, requested
+}
+
+func TestProtectGetMetaInfo(t *testing.T) {
+	t.Parallel()
+
+	c, requested := newProtectTestClient(t)
+
+	info, err := c.GetProtectMetaInfo()
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	a := assert.New(t)
+	// The /proxy/ prefix must survive path(): Protect has no /proxy/network app.
+	a.Equal([]string{APIProtectMetaInfoPath}, *requested)
+	a.Equal("5.1.113", info.ApplicationVersion)
+}
+
+// TestProtectMetaInfoNotInstalled confirms a 404 (the "Protect not installed" case) still
+// surfaces as ErrEndpointNotFound after GetProtectMetaInfo's fmt.Errorf wrap. Part 2's
+// collectProtect depends on errors.Is matching through that wrap to detect this case cleanly.
+func TestProtectMetaInfoNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, ProtectAPIKey: "protect-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    true,
+	}
+
+	_, err := c.GetProtectMetaInfo()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEndpointNotFound)
+}
+
+func TestProtectAuthUsesProtectAPIKey(t *testing.T) {
+	t.Parallel()
+
+	var gotAPIKey, gotCSRF string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("X-API-Key")
+		gotCSRF = r.Header.Get("X-CSRF-Token")
+
+		body, err := os.ReadFile("endpoints_data/protect-meta-info.json")
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, ProtectAPIKey: "protect-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    true,
+		csrf:   "network-csrf-should-not-be-used",
+	}
+
+	_, err := c.GetProtectMetaInfo()
+	require.NoError(t, err)
+
+	a := assert.New(t)
+	a.Equal("protect-key-abc", gotAPIKey)
+	a.Empty(gotCSRF)
+}
+
+func TestProtectAuthFallsBackToAPIKey(t *testing.T) {
+	t.Parallel()
+
+	var gotAPIKey string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("X-API-Key")
+
+		body, err := os.ReadFile("endpoints_data/protect-meta-info.json")
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, APIKey: "network-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    true,
+	}
+
+	_, err := c.GetProtectMetaInfo()
+	require.NoError(t, err)
+	assert.Equal(t, "network-key-abc", gotAPIKey)
+}
+
+func TestProtectGetSensors(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newProtectTestClient(t)
+
+	sensors, err := c.GetProtectSensors()
+	require.NoError(t, err)
+	require.Len(t, sensors, 2)
+
+	a := assert.New(t)
+
+	s1 := sensors[0]
+	a.Equal("sensor-1", s1.ID)
+	a.Equal("sensor", s1.ModelKey)
+	a.Equal("CONNECTED", s1.State)
+	a.Equal("door", s1.MountType)
+	require.NotNil(t, s1.BatteryStatus.Percentage)
+	a.InDelta(87, *s1.BatteryStatus.Percentage, 0.001)
+	require.NotNil(t, s1.Stats.Temperature.Value)
+	a.InDelta(21.5, *s1.Stats.Temperature.Value, 0.001)
+	a.Equal("bridge-1", s1.WirelessConnectionState.Bridge)
+
+	// A sensor with no battery reports a nil pointer, never a zeroed 0 -- that distinction
+	// is the whole reason Protect fields use pointers instead of FlexInt.
+	s2 := sensors[1]
+	a.Equal("sensor-2", s2.ID)
+	a.Nil(s2.BatteryStatus.Percentage)
+	a.Nil(s2.Stats.Temperature)
+	require.NotNil(t, s2.LeakDetectedAt)
+	a.Equal(int64(1734000500000), *s2.LeakDetectedAt)
+}
+
+func TestProtectGetCameras(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newProtectTestClient(t)
+
+	cameras, err := c.GetProtectCameras()
+	require.NoError(t, err)
+	require.Len(t, cameras, 2)
+
+	a := assert.New(t)
+	a.Equal("camera-1", cameras[0].ID)
+	a.Equal("CONNECTED", cameras[0].State)
+	a.True(cameras[0].HasPackageCamera)
+	a.Equal("DISCONNECTED", cameras[1].State)
+}
+
+func TestProtectGetLights(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newProtectTestClient(t)
+
+	lights, err := c.GetProtectLights()
+	require.NoError(t, err)
+	require.Len(t, lights, 1)
+
+	a := assert.New(t)
+	a.Equal("light-1", lights[0].ID)
+	a.True(lights[0].IsLightOn)
+	require.NotNil(t, lights[0].LightDeviceSettings)
+	a.Equal(3, lights[0].LightDeviceSettings.LEDLevel)
+}
+
+func TestProtectGetBridges(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newProtectTestClient(t)
+
+	bridges, err := c.GetProtectBridges()
+	require.NoError(t, err)
+	require.Len(t, bridges, 1)
+
+	a := assert.New(t)
+	a.Equal("bridge-1", bridges[0].ID)
+	a.Len(bridges[0].Clients, 2)
+	a.Equal(32, bridges[0].MaxClients)
+}
+
+func TestProtectGetLinkStations(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newProtectTestClient(t)
+
+	stations, err := c.GetProtectLinkStations()
+	require.NoError(t, err)
+	require.Len(t, stations, 2)
+
+	a := assert.New(t)
+
+	hub := stations[0]
+	a.Equal("linkstation-1", hub.ID)
+	a.True(hub.IsAlarmHub)
+	require.NotNil(t, hub.AlarmHub)
+	a.True(hub.AlarmHub.Armed)
+	require.NotNil(t, hub.AlarmHub.Battery.Voltage)
+	a.InDelta(13.2, *hub.AlarmHub.Battery.Voltage, 0.001)
+	require.NotNil(t, hub.AlarmHub.InputPower.BT)
+	a.InDelta(12.1, *hub.AlarmHub.InputPower.BT, 0.001)
+	a.Nil(hub.AlarmHub.InputPower.Typ1)
+
+	notHub := stations[1]
+	a.False(notHub.IsAlarmHub)
+	a.Nil(notHub.AlarmHub)
+}
+
+func TestProtectGetNVR(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newProtectTestClient(t)
+
+	nvr, err := c.GetProtectNVR()
+	require.NoError(t, err)
+	require.NotNil(t, nvr)
+
+	a := assert.New(t)
+	a.Equal("nvr-1", nvr.ID)
+	require.NotNil(t, nvr.ArmMode)
+	a.Equal("armed", nvr.ArmMode.Status)
+	a.Equal(0, nvr.ArmMode.BreachEventCount)
+}
+
+func TestProtectGetDevices(t *testing.T) {
+	t.Parallel()
+
+	c, requested := newProtectTestClient(t)
+
+	device, err := c.GetProtectDevices()
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	a := assert.New(t)
+	a.Len(*requested, protectEndpointCount)
+	a.NotEmpty(device.SourceName)
+	a.Len(device.Sensors, 2)
+	a.Len(device.Cameras, 2)
+	a.Len(device.Lights, 1)
+	a.Len(device.Bridges, 1)
+	a.Len(device.LinkStations, 2)
+	a.NotNil(device.NVR)
+}
+
+func TestProtectGetDevicesPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	c, requested := newProtectTestClient(t, APIProtectLightsPath)
+
+	logged := []string{}
+	c.ErrorLog = func(msg string, v ...any) {
+		logged = append(logged, fmt.Sprintf(msg, v...))
+	}
+
+	device, err := c.GetProtectDevices()
+	// A console that will not serve one endpoint still reports the rest, and a partial
+	// failure is deliberately not an error -- an `if err != nil { return }` at the call
+	// site would otherwise discard every metric this console can still supply.
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	a := assert.New(t)
+	a.Len(logged, 1, "the endpoint that failed is reported through ErrorLog instead")
+	a.Contains(logged[0], "lights")
+	a.Len(*requested, protectEndpointCount, "every endpoint is attempted even after one fails")
+	a.Len(device.Sensors, 2)
+	a.Empty(device.Lights)
+	a.NotNil(device.NVR)
+}
+
+func TestProtectGetDevicesTotalFailure(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newProtectTestClient(t,
+		APIProtectSensorsPath, APIProtectCamerasPath, APIProtectLightsPath,
+		APIProtectBridgesPath, APIProtectLinkStationsPath, APIProtectNVRPath)
+
+	device, err := c.GetProtectDevices()
+	// Total failure is now the only case that returns an error, and it returns no device.
+	require.Error(t, err)
+	require.Nil(t, device)
+	// The joined error names every endpoint, so an operator sees the whole picture at once.
+	require.Contains(t, err.Error(), "sensors")
+	require.Contains(t, err.Error(), "cameras")
+	require.Contains(t, err.Error(), "lights")
+	require.Contains(t, err.Error(), "bridges")
+	require.Contains(t, err.Error(), "link stations")
+	require.Contains(t, err.Error(), "NVR")
+}
+
+func TestProtectNilReceivers(t *testing.T) {
+	t.Parallel()
+
+	var c *Unifi
+
+	a := assert.New(t)
+
+	_, err := c.GetProtectDevices()
+	a.ErrorIs(err, ErrNilUnifi)
+
+	_, err = c.GetProtectMetaInfo()
+	a.ErrorIs(err, ErrNilUnifi)
+
+	_, err = c.GetProtectSensors()
+	a.ErrorIs(err, ErrNilUnifi)
+
+	_, err = c.GetProtectCameras()
+	a.ErrorIs(err, ErrNilUnifi)
+
+	_, err = c.GetProtectLights()
+	a.ErrorIs(err, ErrNilUnifi)
+
+	_, err = c.GetProtectBridges()
+	a.ErrorIs(err, ErrNilUnifi)
+
+	_, err = c.GetProtectLinkStations()
+	a.ErrorIs(err, ErrNilUnifi)
+
+	_, err = c.GetProtectNVR()
+	a.ErrorIs(err, ErrNilUnifi)
+}
+
+func TestProtectStateValue(t *testing.T) {
+	t.Parallel()
+
+	a := assert.New(t)
+	a.InDelta(2.0, ProtectStateValue("CONNECTED"), 0.001)
+	a.InDelta(1.0, ProtectStateValue("CONNECTING"), 0.001)
+	a.InDelta(0.0, ProtectStateValue("DISCONNECTED"), 0.001)
+	a.InDelta(-1.0, ProtectStateValue("UNKNOWN_STATE"), 0.001)
+	a.InDelta(-1.0, ProtectStateValue(""), 0.001)
+}
+
+func TestProtectStructs(t *testing.T) {
+	t.Parallel()
+
+	var sensor ProtectSensor
+
+	require.NoError(t, gofakeit.Struct(&sensor))
+	require.NotEmpty(t, sensor.ID)
+
+	var camera ProtectCamera
+
+	require.NoError(t, gofakeit.Struct(&camera))
+
+	var light ProtectLight
+
+	require.NoError(t, gofakeit.Struct(&light))
+
+	var bridge ProtectBridge
+
+	require.NoError(t, gofakeit.Struct(&bridge))
+
+	var station ProtectLinkStation
+
+	require.NoError(t, gofakeit.Struct(&station))
+
+	var nvr ProtectNVR
+
+	require.NoError(t, gofakeit.Struct(&nvr))
+
+	var devices ProtectDevices
+
+	require.NoError(t, gofakeit.Struct(&devices))
+	require.Len(t, devices.Sensors, 5)
+}

--- a/protect_test.go
+++ b/protect_test.go
@@ -180,20 +180,18 @@ func TestProtectGetSensors(t *testing.T) {
 	a.Equal("sensor", s1.ModelKey)
 	a.Equal("CONNECTED", s1.State)
 	a.Equal("door", s1.MountType)
-	require.NotNil(t, s1.BatteryStatus.Percentage)
-	a.InDelta(87, *s1.BatteryStatus.Percentage, 0.001)
-	require.NotNil(t, s1.Stats.Temperature.Value)
-	a.InDelta(21.5, *s1.Stats.Temperature.Value, 0.001)
+	a.InDelta(87, s1.BatteryStatus.Percentage.Float64(), 0.001)
+	require.NotNil(t, s1.Stats.Temperature)
+	a.InDelta(21.5, s1.Stats.Temperature.Value.Float64(), 0.001)
 	a.Equal("bridge-1", s1.WirelessConnectionState.Bridge)
 
-	// A sensor with no battery reports a nil pointer, never a zeroed 0 -- that distinction
-	// is the whole reason Protect fields use pointers instead of FlexInt.
+	// A sensor with no battery reports a JSON null, which FlexFloat collapses to 0 -- this
+	// is the accepted tradeoff of using Flex* types uniformly instead of nullable pointers.
 	s2 := sensors[1]
 	a.Equal("sensor-2", s2.ID)
-	a.Nil(s2.BatteryStatus.Percentage)
+	a.InDelta(0, s2.BatteryStatus.Percentage.Float64(), 0.001)
 	a.Nil(s2.Stats.Temperature)
-	require.NotNil(t, s2.LeakDetectedAt)
-	a.Equal(int64(1734000500000), *s2.LeakDetectedAt)
+	a.Equal(int64(1734000500000), s2.LeakDetectedAt.Int64())
 }
 
 func TestProtectGetCameras(t *testing.T) {
@@ -208,7 +206,7 @@ func TestProtectGetCameras(t *testing.T) {
 	a := assert.New(t)
 	a.Equal("camera-1", cameras[0].ID)
 	a.Equal("CONNECTED", cameras[0].State)
-	a.True(cameras[0].HasPackageCamera)
+	a.True(cameras[0].HasPackageCamera.Val)
 	a.Equal("DISCONNECTED", cameras[1].State)
 }
 
@@ -223,9 +221,9 @@ func TestProtectGetLights(t *testing.T) {
 
 	a := assert.New(t)
 	a.Equal("light-1", lights[0].ID)
-	a.True(lights[0].IsLightOn)
+	a.True(lights[0].IsLightOn.Val)
 	require.NotNil(t, lights[0].LightDeviceSettings)
-	a.Equal(3, lights[0].LightDeviceSettings.LEDLevel)
+	a.Equal(3, lights[0].LightDeviceSettings.LEDLevel.Int())
 }
 
 func TestProtectGetBridges(t *testing.T) {
@@ -240,7 +238,7 @@ func TestProtectGetBridges(t *testing.T) {
 	a := assert.New(t)
 	a.Equal("bridge-1", bridges[0].ID)
 	a.Len(bridges[0].Clients, 2)
-	a.Equal(32, bridges[0].MaxClients)
+	a.Equal(32, bridges[0].MaxClients.Int())
 }
 
 func TestProtectGetLinkStations(t *testing.T) {
@@ -256,17 +254,18 @@ func TestProtectGetLinkStations(t *testing.T) {
 
 	hub := stations[0]
 	a.Equal("linkstation-1", hub.ID)
-	a.True(hub.IsAlarmHub)
+	a.True(hub.IsAlarmHub.Val)
 	require.NotNil(t, hub.AlarmHub)
-	a.True(hub.AlarmHub.Armed)
-	require.NotNil(t, hub.AlarmHub.Battery.Voltage)
-	a.InDelta(13.2, *hub.AlarmHub.Battery.Voltage, 0.001)
-	require.NotNil(t, hub.AlarmHub.InputPower.BT)
-	a.InDelta(12.1, *hub.AlarmHub.InputPower.BT, 0.001)
-	a.Nil(hub.AlarmHub.InputPower.Typ1)
+	a.True(hub.AlarmHub.Armed.Val)
+	require.NotNil(t, hub.AlarmHub.Battery)
+	a.InDelta(13.2, hub.AlarmHub.Battery.Voltage.Float64(), 0.001)
+	require.NotNil(t, hub.AlarmHub.InputPower)
+	a.InDelta(12.1, hub.AlarmHub.InputPower.BT.Float64(), 0.001)
+	// Typ1 is null in the fixture; FlexFloat collapses that to 0, same as a real 0 reading.
+	a.InDelta(0, hub.AlarmHub.InputPower.Typ1.Float64(), 0.001)
 
 	notHub := stations[1]
-	a.False(notHub.IsAlarmHub)
+	a.False(notHub.IsAlarmHub.Val)
 	a.Nil(notHub.AlarmHub)
 }
 
@@ -283,7 +282,7 @@ func TestProtectGetNVR(t *testing.T) {
 	a.Equal("nvr-1", nvr.ID)
 	require.NotNil(t, nvr.ArmMode)
 	a.Equal("armed", nvr.ArmMode.Status)
-	a.Equal(0, nvr.ArmMode.BreachEventCount)
+	a.Equal(0, nvr.ArmMode.BreachEventCount.Int())
 }
 
 func TestProtectGetDevices(t *testing.T) {

--- a/radius_profiles_test.go
+++ b/radius_profiles_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestRADIUSProfileMetadata(t *testing.T) {

--- a/ssl_cert_test.go
+++ b/ssl_cert_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestSSLCertificateStruct(t *testing.T) {

--- a/switching_test.go
+++ b/switching_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestLAG(t *testing.T) {

--- a/traffic_matching_lists_test.go
+++ b/traffic_matching_lists_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestTrafficMatchingList(t *testing.T) {

--- a/traffic_test.go
+++ b/traffic_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestClientUsageByApp(test *testing.T) {

--- a/types.go
+++ b/types.go
@@ -991,6 +991,78 @@ func (f FlexInt) Fake(faker *gofakeit.Faker) interface{} {
 	}
 }
 
+// FlexFloat provides a container and unmarshalling for fields that may be
+// numbers or strings in the Unifi API, without FlexInt's implication of an integer value.
+type FlexFloat struct {
+	Val float64
+	Txt string
+}
+
+func NewFlexFloat(v float64) *FlexFloat {
+	return &FlexFloat{
+		Val: v,
+		Txt: strconv.FormatFloat(v, 'f', -1, 64),
+	}
+}
+
+// UnmarshalJSON converts a string, number, or null to a float64.
+// Generally, do not call this directly, it's used in the json interface.
+func (f *FlexFloat) UnmarshalJSON(b []byte) error {
+	var unk interface{}
+
+	if err := json.Unmarshal(b, &unk); err != nil {
+		return fmt.Errorf("json unmarshal: %w", err)
+	}
+
+	switch i := unk.(type) {
+	case float64:
+		f.Val = i
+		f.Txt = strconv.FormatFloat(i, 'f', -1, 64)
+	case string:
+		f.Txt = i
+		f.Val, _ = strconv.ParseFloat(i, 64)
+	case nil:
+		f.Txt = "0"
+		f.Val = 0
+	default:
+		return fmt.Errorf("%v: %w", b, ErrCannotUnmarshalFlexInt)
+	}
+
+	return nil
+}
+
+func (f FlexFloat) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.Val)
+}
+
+func (f *FlexFloat) Float64() float64 {
+	return f.Val
+}
+
+func (f *FlexFloat) String() string {
+	return f.Txt
+}
+
+func (f *FlexFloat) Add(o *FlexFloat) {
+	f.Val += o.Val
+	f.Txt = strconv.FormatFloat(f.Val, 'f', -1, 64)
+}
+
+func (f *FlexFloat) AddFloat64(v float64) {
+	f.Val += v
+	f.Txt = strconv.FormatFloat(f.Val, 'f', -1, 64)
+}
+
+// Fake implements gofakeit Fake interface
+func (f FlexFloat) Fake(faker *gofakeit.Faker) interface{} {
+	randValue := math.Min(math.Max(0.1, math.Abs(faker.Rand.Float64())), 500)
+
+	return FlexFloat{
+		Val: randValue,
+		Txt: strconv.FormatFloat(randValue, 'f', 8, 64),
+	}
+}
+
 // FlexBool provides a container and unmarshalling for fields that may be
 // boolean or strings in the Unifi API.
 type FlexBool struct {

--- a/types.go
+++ b/types.go
@@ -229,6 +229,18 @@ const (
 	APIUNASNetworkIOPath  string = "/proxy/drive/api/v2/systems/network-io"
 	APIUNASDrivesPath     string = "/proxy/users/drive/api/v2/drives"
 
+	// Protect Integration API paths. Require X-API-Key auth (ProtectAPIKey in Config,
+	// falling back to APIKey). Already start with /proxy/ so path() leaves them untouched.
+	// See unpoller/unpoller#1015.
+	APIProtectIntegrationPrefix string = "/proxy/protect/integration"
+	APIProtectMetaInfoPath      string = "/proxy/protect/integration/v1/meta/info"
+	APIProtectSensorsPath       string = "/proxy/protect/integration/v1/sensors"
+	APIProtectCamerasPath       string = "/proxy/protect/integration/v1/cameras"
+	APIProtectLightsPath        string = "/proxy/protect/integration/v1/lights"
+	APIProtectBridgesPath       string = "/proxy/protect/integration/v1/bridges"
+	APIProtectLinkStationsPath  string = "/proxy/protect/integration/v1/link-stations"
+	APIProtectNVRPath           string = "/proxy/protect/integration/v1/nvrs"
+
 	// Legacy gap API paths (Part A).
 	APIWANStatusPath   string = "/api/s/%s/stat/status"
 	APIUPSDevicesPath  string = "/api/s/%s/stat/ups-devices"
@@ -289,6 +301,11 @@ type Config struct {
 	DebugLog  Logger
 	Timeout   time.Duration // how long to wait for replies, default: forever.
 	VerifySSL bool
+	// ProtectAPIKey authenticates requests to the Protect Integration API
+	// (APIProtectIntegrationPrefix). It is independent of APIKey, which
+	// authenticates the Network Integration API and, when set, changes how
+	// Login() behaves for Network. Falls back to APIKey if empty.
+	ProtectAPIKey string
 }
 
 // IntegrationSite holds site identity from GET /proxy/network/integration/v1/sites.

--- a/types_test.go
+++ b/types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestFlexInt(t *testing.T) {

--- a/ubb_issue_test.go
+++ b/ubb_issue_test.go
@@ -3,7 +3,7 @@ package unifi_test
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 	"testing"
 )
 

--- a/ubb_test.go
+++ b/ubb_test.go
@@ -3,7 +3,7 @@ package unifi_test
 import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 	"testing"
 )
 

--- a/uci_test.go
+++ b/uci_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestUCI(test *testing.T) {

--- a/udb_test.go
+++ b/udb_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestUDB(test *testing.T) {

--- a/unifi.go
+++ b/unifi.go
@@ -607,9 +607,19 @@ func (u *Unifi) do(req *http.Request) ([]byte, error) {
 }
 
 func (u *Unifi) setHeaders(req *http.Request, params string) {
-	if u.APIKey != "" {
+	// Protect's Integration API authenticates with its own key, independent of the
+	// Network session. Everything else keeps the existing cookie/CSRF or APIKey behavior.
+	protectKey := u.ProtectAPIKey
+	if protectKey == "" {
+		protectKey = u.APIKey
+	}
+
+	switch {
+	case strings.HasPrefix(req.URL.Path, APIProtectIntegrationPrefix) && protectKey != "":
+		req.Header.Set("X-API-Key", protectKey)
+	case u.APIKey != "":
 		req.Header.Set("X-API-Key", u.APIKey)
-	} else {
+	default:
 		// Add the saved CSRF header.
 		req.Header.Set("X-CSRF-Token", u.csrf)
 	}

--- a/ups_device_selector_test.go
+++ b/ups_device_selector_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestUPSDeviceSelectorStruct(t *testing.T) {

--- a/vpn_servers_test.go
+++ b/vpn_servers_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestVPNServer(t *testing.T) {

--- a/wan_status_test.go
+++ b/wan_status_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestWANStatusStruct(t *testing.T) {

--- a/wifi_broadcasts_test.go
+++ b/wifi_broadcasts_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
-	"github.com/unpoller/unifi/v5"
+	"github.com/unpoller/unifi/v6"
 )
 
 func TestWifiBroadcast(t *testing.T) {


### PR DESCRIPTION
## Summary

Part of unpoller/unpoller#1015 — Part 1 (library) of a two-repo change. This is `unpoller/unpoller#1015`'s concrete ask: SuperLink sensor data (and the rest of the Protect device estate) via Ubiquiti's official, documented [Protect Integration API](https://developer.ui.com/protect/), not the private bootstrap API.

- New `protect.go`: types + getters for `/v1/{sensors,cameras,lights,bridges,link-stations,nvrs}` and `/v1/meta/info`, plus `GetProtectDevices()` aggregating all six with UNAS-style partial-failure semantics (error only when every endpoint fails).
- Path-aware auth in `setHeaders`/`Config`: Protect paths use a new `ProtectAPIKey` (`X-API-Key`), falling back to the existing `APIKey` if unset; Network paths are unaffected.
- Getters are intentionally **not** on the `UnifiClient` interface (mirrors UNAS) — avoids forcing matching methods onto `MockUnifi`.
- New `FlexFloat` type (mirrors `FlexInt`/`FlexTemp`). All scalar bool/int/float fields in `protect.go` — including fields the spec declares nullable (battery %, sensor stat values, signal strength/quality, thresholds, `*DetectedAt` timestamps) — use `FlexBool`/`FlexInt`/`FlexFloat` uniformly, consistent with the rest of the library. **Deliberate tradeoff:** these types collapse a JSON `null` to `0`/`false`, so "no battery" and "battery at 0%" are indistinguishable through them. Chosen over nullable pointers for typing consistency; see `ENDPOINTS.md`'s fixture disclaimer for the same note plus a caveat that `FlexBool`/`FlexInt`/`FlexFloat` unmarshal permissively and won't error on an unexpected wire shape.
- Undocumented-shape `object` fields (e.g. `glassBreakSettings`, camera `osdSettings`/`ledSettings`/`featureFlags`, alarm-hub power/terminal-status fields) are kept as `json.RawMessage` rather than guessed at, per the UNAS convention.
- `ENDPOINTS.md` updated with implemented / known-not-implemented tables and a synthetic-fixture disclaimer.

## Caveat — fixtures are unverified against real hardware

All 7 JSON fixtures under `endpoints_data/protect-*.json` are **synthetic**, hand-authored from the OpenAPI spec — not captured from a real Protect console. Field shapes, nullability, and the auth fallback behavior (does a Network Integration key also authenticate Protect, or is a separate key required?) are unconfirmed against Ubiquiti's actual wire format. This should be verified against real hardware before or shortly after merge; UNAS Pro support shipped under the same caveat.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (includes new `protect_test.go`: happy path per endpoint, `/proxy/` prefix survival, auth header assertions, partial/total failure, nil receivers, nullable-to-zero round-trip via FlexInt/FlexBool/FlexFloat, `ErrEndpointNotFound` survives the `fmt.Errorf` wrap on 404, `gofakeit.Struct` smoke tests)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Verify against a real Protect console (API key validity, SuperLink sensor payload shape, Network-key-vs-Protect-key auth behavior, and whether any field actually carries epoch-ns instead of epoch-ms timestamps) — not done in this PR, tracked as follow-up before Part 2 (`unpoller/unpoller`) ships end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)