### PR TITLE
feat: add NewProtectClient for Protect-only consoles (UNVR)

### DIFF
--- a/protect.go
+++ b/protect.go
@@ -1,9 +1,15 @@
 package unifi
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 // Protect device support is built on Ubiquiti's official, documented Protect Integration
@@ -323,6 +329,83 @@ type ProtectDevices struct {
 	Lights       []*ProtectLight       `fakesize:"5"`
 	Bridges      []*ProtectBridge      `fakesize:"5"`
 	LinkStations []*ProtectLinkStation `fakesize:"5"`
+}
+
+// NewProtectClient creates a client for a Protect-only UniFi OS console -- a UNVR, UNVR
+// Pro, or any console running UniFi Protect with no Network application installed. Start
+// here for those; keep using NewUnifi for a console that runs Network.
+//
+// This is deliberately not NewUnifi: that constructor finishes with GetServerData(), which
+// GETs /status -- rewritten by path() to /proxy/network/status. A Protect-only console runs
+// no Network application to answer it and serves the UniFi OS SPA HTML instead, so NewUnifi
+// fails with "invalid character '<' looking for beginning of value" and the console can
+// never be polled at all. See unpoller/unpoller#1066. This mirrors NewUNASClient in unas.go,
+// which exists for the same reason.
+//
+// Unlike NewUNASClient this returns a plain *Unifi rather than a wrapper type, because the
+// Protect getters are already *Unifi methods.
+//
+// The returned client's ServerStatus.ServerVersion holds the UniFi *Protect* application
+// version, not a Network one: a Protect-only console has no Network version to report.
+func NewProtectClient(config *Config) (*Unifi, error) {
+	if config == nil {
+		return nil, ErrNilConfig
+	}
+
+	// Integration/v1 authenticates with the X-API-Key header and has no cookie fallback, so
+	// without a key there is nothing this client could successfully request.
+	if config.ProtectAPIKey == "" && config.APIKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	var jar http.CookieJar
+
+	if config.APIKey == "" {
+		var err error
+
+		jar, err = cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+		if err != nil {
+			return nil, fmt.Errorf("creating cookiejar: %w", err)
+		}
+	}
+
+	u := newUnifi(config, jar)
+
+	for i, cert := range config.SSLCert {
+		p, _ := pem.Decode(cert)
+		if p == nil {
+			continue
+		}
+
+		u.fingerprints[i] = fmt.Sprintf("%x", sha256.Sum256(p.Bytes))
+	}
+
+	// A Protect console is always a UniFi OS console, so the new-style API is a given.
+	// Setting this directly rather than calling checkNewStyleAPI() means Login() resolves to
+	// /api/auth/login without depending on how the console answers a GET of /.
+	u.new = true
+
+	// Integration/v1 needs no session. The legacy Protect endpoints do -- GetProtectLogs and
+	// GetProtectEventThumbnail authenticate with a session cookie -- so log in when local
+	// credentials are supplied. Never when APIKey is set: Login() uses /status as its login
+	// path in that case, which is the one endpoint this console does not serve.
+	if config.APIKey == "" && config.User != "" {
+		if err := u.Login(); err != nil {
+			return u, err
+		}
+	}
+
+	// Prove the console answers Protect before handing back a client, the way NewUnifi proves
+	// Network with GetServerData. Populating ServerStatus is not cosmetic: Unifi embeds
+	// *ServerStatus, so leaving it nil makes u.ServerVersion a nil dereference for callers.
+	info, err := u.GetProtectMetaInfo()
+	if err != nil {
+		return u, fmt.Errorf("unable to reach the Protect Integration API: %w", err)
+	}
+
+	u.ServerStatus = &ServerStatus{Up: *NewFlexBool(true), ServerVersion: info.ApplicationVersion}
+
+	return u, nil
 }
 
 // GetProtectMetaInfo returns the Protect application version. This is the cheapest

--- a/protect_test.go
+++ b/protect_test.go
@@ -1,6 +1,7 @@
 package unifi // nolint: testpackage
 
 import (
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -426,4 +427,174 @@ func TestProtectStructs(t *testing.T) {
 
 	require.NoError(t, gofakeit.Struct(&devices))
 	require.Len(t, devices.Sensors, 5)
+}
+
+// newProtectOnlyConsole returns a server that behaves like a UNVR: the Protect Integration
+// paths answer from fixtures, /api/auth/login succeeds, and every Network path -- including
+// the /proxy/network/status that NewUnifi ends on -- serves the UniFi OS SPA HTML that
+// caused unpoller/unpoller#1066. The returned slice records requested paths, in order.
+func newProtectOnlyConsole(t *testing.T) (*httptest.Server, *[]string) {
+	t.Helper()
+
+	requested := &[]string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requested = append(*requested, r.URL.Path)
+
+		if r.URL.Path == APILoginPathNew {
+			w.Header().Set("x-csrf-token", "csrf-abc")
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		file, ok := protectFixtures[r.URL.Path]
+		if !ok {
+			// No Network application to route to, so UniFi OS serves its own SPA.
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<!doctype html><html lang="en"><body></body></html>`))
+
+			return
+		}
+
+		body, err := os.ReadFile(file)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return srv, requested
+}
+
+// TestNewUnifiFailsOnProtectOnlyConsole is the bug NewProtectClient exists to fix, pinned as
+// a test: NewUnifi cannot construct a client for a console with no Network application. If
+// this ever starts passing, NewProtectClient's reason for existing has changed.
+func TestNewUnifiFailsOnProtectOnlyConsole(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newProtectOnlyConsole(t)
+
+	_, err := NewUnifi(&Config{
+		URL: srv.URL, User: "ro-user", Pass: "secret",
+		ProtectAPIKey: "protect-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to get server version")
+}
+
+func TestNewProtectClient(t *testing.T) {
+	t.Parallel()
+
+	srv, requested := newProtectOnlyConsole(t)
+
+	c, err := NewProtectClient(&Config{
+		URL: srv.URL, User: "ro-user", Pass: "secret",
+		ProtectAPIKey: "protect-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	a := assert.New(t)
+	// New-style paths are assumed rather than probed, so nothing but the login and the
+	// reachability probe reaches the console -- and /status is never requested.
+	a.True(c.new)
+	a.Equal([]string{APILoginPathNew, APIProtectMetaInfoPath}, *requested)
+	a.Equal("csrf-abc", c.csrf)
+
+	// ServerStatus must be populated: Unifi embeds *ServerStatus, so a nil one turns every
+	// caller's c.ServerVersion into a panic. The version is Protect's, not Network's.
+	require.NotNil(t, c.ServerStatus)
+	a.Equal("5.1.113", c.ServerVersion)
+	a.True(c.Up.Val)
+}
+
+// TestNewProtectClientSkipsLoginWithAPIKey covers the one case where logging in is actively
+// harmful: Login() routes through /status when Config.APIKey is set, and /status is exactly
+// what a Protect-only console cannot answer.
+func TestNewProtectClientSkipsLoginWithAPIKey(t *testing.T) {
+	t.Parallel()
+
+	srv, requested := newProtectOnlyConsole(t)
+
+	c, err := NewProtectClient(&Config{
+		URL: srv.URL, APIKey: "network-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	assert.Equal(t, []string{APIProtectMetaInfoPath}, *requested)
+}
+
+// TestNewProtectClientSkipsLoginWithoutUser covers a key-only config: an operator with a
+// Protect Integration key but no local account still gets a usable client.
+func TestNewProtectClientSkipsLoginWithoutUser(t *testing.T) {
+	t.Parallel()
+
+	srv, requested := newProtectOnlyConsole(t)
+
+	_, err := NewProtectClient(&Config{
+		URL: srv.URL, ProtectAPIKey: "protect-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{APIProtectMetaInfoPath}, *requested)
+}
+
+func TestNewProtectClientRejectsBadConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewProtectClient(nil)
+	require.ErrorIs(t, err, ErrNilConfig)
+
+	// Integration/v1 is X-API-Key only; user/pass alone can never authenticate it.
+	_, err = NewProtectClient(&Config{URL: "https://127.0.0.1", User: "ro-user", Pass: "secret"})
+	require.ErrorIs(t, err, ErrAPIKeyRequired)
+}
+
+// TestNewProtectClientProtectNotInstalled covers a console that answers neither application.
+// The client is still returned so callers can inspect it, matching NewUnifi's contract.
+func TestNewProtectClientProtectNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewProtectClient(&Config{
+		URL: srv.URL, ProtectAPIKey: "protect-key-abc", DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.ErrorIs(t, err, ErrEndpointNotFound)
+	require.NotNil(t, c)
+	assert.Nil(t, c.ServerStatus)
+}
+
+// TestNewProtectClientPinsSSLCert covers the fingerprint loop NewProtectClient duplicates
+// from NewUnifi. It writes into a slice newUnifi only allocates when SSLCert is non-empty,
+// so an empty-cert regression there is an index panic rather than a failure elsewhere.
+func TestNewProtectClientPinsSSLCert(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"applicationVersion":"7.2.105"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	require.NotNil(t, cert)
+
+	c, err := NewProtectClient(&Config{
+		URL: srv.URL, ProtectAPIKey: "protect-key-abc", SSLCert: [][]byte{cert},
+		DebugLog: discardLogs, ErrorLog: discardLogs,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	a := assert.New(t)
+	a.Len(c.fingerprints, 1)
+	a.NotNil(c.Transport)
+	a.Equal("7.2.105", c.ServerVersion)
 }


### PR DESCRIPTION
Fixes the library half of https://github.com/unpoller/unpoller/issues/1066.

## The problem

A **Protect-only console** — a UNVR, UNVR Pro, or any console running UniFi Protect with no Network application installed — cannot be constructed with `NewUnifi` at all.

`NewUnifi` finishes with `GetServerData()`, which GETs `/status`, rewritten by `path()` to `/proxy/network/status`. With no Network application to route to, UniFi OS serves its own SPA HTML, and the call fails on the first byte of it:

```
[ERROR] Controller 3 of 3 Auth or Connection Error, retrying: unifi controller:
        unable to get server version: invalid character '<' looking for beginning of value
```

The console is therefore unreachable even though its Protect Integration API answers all seven endpoints with the same key. In unpoller this means `save_protect_devices` is unreachable on exactly the hardware most likely to want it.

## The change

`NewProtectClient` is the Protect equivalent of `NewUNASClient`, which exists for the same underlying reason — a UniFi OS console with no Network application. It allocates the client, assumes new-style API paths, logs in only when a session is actually useful, and ends by probing `/v1/meta/info` the way `NewUnifi` ends by probing Network, so a caller that gets no error has a console it can really poll.

Three details worth a reviewer's attention:

- **It returns a plain `*Unifi`, unlike `NewUNASClient`.** The Protect getters are already `*Unifi` methods, so a wrapper type would add a type without adding safety.
- **Login is skipped when `Config.APIKey` is set.** `Login()` routes through `/status` in that case — precisely the endpoint this console does not serve. It is also skipped when `User` is empty, so a key-only config works. It still runs for user/pass, because the legacy Protect endpoints (`GetProtectLogs`, `GetProtectEventThumbnail`) authenticate with a session cookie.
- **`ServerStatus` is populated, and that is not cosmetic.** `Unifi` embeds `*ServerStatus`, so leaving it nil turns any caller's `u.ServerVersion` into a nil dereference — including `inputunifi`'s config summary today. `ServerVersion` holds the *Protect* application version, since a Protect-only console has no Network version to report. This is documented on the constructor.

## Why not extend `NewUnifi`?

It is a behavioural fork rather than a tweak: no Network probe, no `checkNewStyleAPI`, and a different auth story. The library already has this exact precedent in `NewUNASClient`, so this follows that shape and cross-references it.

## A follow-up PR is coming

A companion PR to **unpoller/unpoller** adds the `disable_network` per-controller config option — the shape @platinummonkey asked for on unpoller/unpoller#1066 — which:

- selects this constructor in `inputunifi.getUnifi()`;
- skips site discovery and all Network collection in `pollController` and `collectControllerEvents`;
- counts a Protect-only controller as a successful poll (today zero devices and zero clients reads as failure on a filtered scrape);
- ships example-config, README and test updates.

It defaults to `false`, so existing behaviour is untouched.

**Why they are split:** `unpoller` consumes `unpoller/unifi` as a tagged module, so this constructor has to exist and be released before anything can call it — landing them together isn't possible. The unpoller PR will stay a draft until this one is tagged. A release tag after merge would be much appreciated.

## Tests

Seven tests, added to `protect_test.go` in that file's existing style, against an `httptest` fake UNVR: SPA HTML on every Network path, 200 + CSRF on `/api/auth/login`, fixtures on the Integration paths.

- `TestNewUnifiFailsOnProtectOnlyConsole` — pins the original bug, so if `NewUnifi` ever starts working here the change in premise is visible.
- `TestNewProtectClient` — succeeds, requests only the login and the probe (never `/status`), captures CSRF, populates `ServerStatus`.
- Login correctly skipped with `APIKey` set, and with no `User`.
- `nil` config → `ErrNilConfig`; no key at all → `ErrAPIKeyRequired`.
- Protect not installed (404) → error, with the client still returned, matching `NewUnifi`'s contract.
- SSL cert pinning, covering the fingerprint loop duplicated from `NewUnifi`.

`go build ./...`, `go test ./...` and `golangci-lint run` (v2.13, per CI) are all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVreutpEATmBjm6PBw9RjQ
