### PR TITLE
fix(wan): read WAN status from the v2 endpoint on UniFi OS

### DIFF
--- a/wan_status.go
+++ b/wan_status.go
@@ -17,7 +17,13 @@ type WANStatusInterface struct {
 }
 
 // GetWANStatus returns the WAN interface status for a single site.
-// Uses the legacy API endpoint: GET /api/s/{site}/stat/status.
+//
+// Two endpoints serve this payload, and which one answers depends on the
+// controller. UniFi OS consoles (UDM, UDR, UXG, cloud keys) return an empty
+// body on the legacy GET /api/s/{site}/stat/status — no error, no interfaces —
+// so callers see a site with no WAN at all. The same interfaces are served by
+// GET /proxy/network/v2/api/site/{site}/wan/load-balancing/status, without the
+// legacy "data" envelope. Classic controllers only have the legacy endpoint.
 // When no WAN data is returned (e.g. site has no gateway), a zero-value WANStatus with an
 // empty WANInterfaces slice is returned. Callers can detect this by checking len(status.WANInterfaces) == 0.
 func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
@@ -30,6 +36,10 @@ func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
 	}
 
 	u.DebugLog("Polling Controller for WAN status, site %s", site.Name)
+
+	if u.new {
+		return u.wanStatusV2(site)
+	}
 
 	path := fmt.Sprintf(APIWANStatusPath, site.Name)
 
@@ -54,4 +64,24 @@ func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
 	response.Data[0].SiteName = site.SiteName
 
 	return &response.Data[0], nil
+}
+
+// wanStatusV2 reads WAN interface status from the v2 load-balancing endpoint,
+// used by UniFi OS consoles. The response is the WANStatus object itself; there
+// is no "data" array to unwrap, unlike the legacy endpoint.
+func (u *Unifi) wanStatusV2(site *Site) (*WANStatus, error) {
+	path := fmt.Sprintf(APIWANLoadBalancingStatusPath, site.Name)
+
+	status := &WANStatus{}
+	if err := u.GetData(path, status); err != nil {
+		return nil, fmt.Errorf("fetching WAN status for site %s: %w", site.Name, err)
+	}
+
+	if len(status.WANInterfaces) == 0 {
+		u.DebugLog("No WAN status found for site %s", site.Name)
+	}
+
+	status.SiteName = site.SiteName
+
+	return status, nil
 }

--- a/wan_status_endpoint_test.go
+++ b/wan_status_endpoint_test.go
@@ -1,0 +1,102 @@
+package unifi // nolint: testpackage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Payload observed on a UDR running UniFi OS: the v2 load-balancing endpoint
+// answers with the interfaces at the top level, no "data" envelope.
+const wanStatusV2Body = `{"wan_interfaces":[
+	{"name":"Internet 1","state":"ACTIVE","wan_networkgroup":"WAN"},
+	{"name":"Internet 2","state":"BACKUP","wan_networkgroup":"WAN2"},
+	{"name":"Cellular","state":"BACKUP","wan_networkgroup":"WAN3"}
+]}`
+
+// The legacy endpoint wraps the same object in a "data" array.
+const wanStatusLegacyBody = `{"data":[{"wan_interfaces":[
+	{"name":"Internet 1","state":"ACTIVE","wan_networkgroup":"WAN"}
+]}]}`
+
+func wanStatusServer(t *testing.T, body string) (*httptest.Server, *[]string) {
+	t.Helper()
+
+	requested := &[]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requested = append(*requested, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, requested
+}
+
+func wanStatusClient(srv *httptest.Server, unifiOS bool) *Unifi {
+	return &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    unifiOS,
+	}
+}
+
+// TestGetWANStatusUnifiOS is the regression this change exists for: a UniFi OS
+// console answers the legacy /stat/status endpoint with no interfaces at all —
+// no error, just an empty result — so every caller saw a site with no WAN. The
+// interfaces must be read from the v2 load-balancing endpoint instead.
+func TestGetWANStatusUnifiOS(t *testing.T) {
+	t.Parallel()
+
+	srv, requested := wanStatusServer(t, wanStatusV2Body)
+	c := wanStatusClient(srv, true)
+
+	status, err := c.GetWANStatus(&Site{Name: "default", SiteName: "Default (default)"})
+	require.NoError(t, err)
+	require.Len(t, status.WANInterfaces, 3)
+
+	a := assert.New(t)
+	a.Equal([]string{"/proxy/network/v2/api/site/default/wan/load-balancing/status"}, *requested)
+	a.Equal("Internet 1", status.WANInterfaces[0].Name)
+	a.Equal("ACTIVE", status.WANInterfaces[0].State)
+	a.Equal("WAN", status.WANInterfaces[0].WANNetworkgroup)
+	a.Equal("BACKUP", status.WANInterfaces[2].State)
+	// SiteName carries json:"-", so it survives the unmarshal and must be set.
+	a.Equal("Default (default)", status.SiteName)
+}
+
+// TestGetWANStatusClassic pins the old behaviour: a classic controller has no
+// v2 endpoint, so the legacy path and its "data" envelope must keep working.
+func TestGetWANStatusClassic(t *testing.T) {
+	t.Parallel()
+
+	srv, requested := wanStatusServer(t, wanStatusLegacyBody)
+	c := wanStatusClient(srv, false)
+
+	status, err := c.GetWANStatus(&Site{Name: "default", SiteName: "Default (default)"})
+	require.NoError(t, err)
+	require.Len(t, status.WANInterfaces, 1)
+
+	a := assert.New(t)
+	a.Equal([]string{"/api/s/default/stat/status"}, *requested)
+	a.Equal("ACTIVE", status.WANInterfaces[0].State)
+	a.Equal("Default (default)", status.SiteName)
+}
+
+// TestGetWANStatusUnifiOSNoGateway covers a site with no gateway: the endpoint
+// answers with an empty object. That is not an error, and callers detect it by
+// checking len(status.WANInterfaces) == 0, as the doc comment promises.
+func TestGetWANStatusUnifiOSNoGateway(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := wanStatusServer(t, `{}`)
+	c := wanStatusClient(srv, true)
+
+	status, err := c.GetWANStatus(&Site{Name: "default", SiteName: "Default (default)"})
+	require.NoError(t, err)
+	assert.Empty(t, status.WANInterfaces)
+	assert.Equal(t, "Default (default)", status.SiteName)
+}


### PR DESCRIPTION
### The problem

`GetWANStatus` queries the legacy `GET /api/s/{site}/stat/status`. UniFi OS consoles (UDM, UDR, UXG) answer it with **no interfaces at all** — no error, no `data`, just an empty result. `GetWANStatus` then takes its `len(response.Data) == 0` branch and returns a zero-value `WANStatus`, so every caller sees a site with no WAN, and `unpoller_wan_interface_state` is never exported for that controller.

That metric was added in unpoller v3.5.0 specifically to expose `ACTIVE` / `BACKUP` / `DISCONNECTED`. On UniFi OS hardware it has never produced a sample.

### The fix

The same interfaces are served by the v2 endpoint:

```
GET /proxy/network/v2/api/site/{site}/wan/load-balancing/status
```

Its path constant, `APIWANLoadBalancingStatusPath`, already exists in `types.go`. The response is the `WANStatus` object itself, without the legacy `data` envelope, so it needs its own small decode path — hence `wanStatusV2`.

Observed on a UDR running UniFi OS 5.1.31:

```json
{"wan_interfaces":[
  {"name":"Internet 1","state":"ACTIVE","wan_networkgroup":"WAN"},
  {"name":"Internet 2","state":"BACKUP","wan_networkgroup":"WAN2"},
  {"name":"Cellular","state":"BACKUP","wan_networkgroup":"WAN3"}
]}
```

while `/api/s/default/stat/status` returns nothing usable on that same console. `WANStatusInterface` already matches this shape field for field, so no struct change is needed.

### Why classic controllers cannot regress

Nothing in the existing code changed. This adds an early branch taken only when `u.new` is set, plus a new function below it. A classic controller runs the same instructions as before.

`checkNewStyleAPI()` derives `u.new` from an **unauthenticated** `GET /` — 200 on UniFi OS, 302 to `/manage` on classic — so which branch a controller takes can be confirmed without credentials. Checked against real hardware of both generations:

| Controller | `GET /` | `u.new` | Branch |
|---|---|---|---|
| Network Application, `:8443` | 302 → `/manage` | `false` | legacy, unchanged |
| Network Application, `:8443` | 302 → `/manage` | `false` | legacy, unchanged |
| UDR, UniFi OS | 200 | `true` | new |

### Tests

`wan_status_endpoint_test.go` uses an `httptest` server and covers three cases:

- **`TestGetWANStatusUnifiOS`** — requests the v2 path, parses the three interfaces, preserves `SiteName` (which carries `json:"-"`). **Fails on `master`, passes with this change.**
- **`TestGetWANStatusClassic`** — a classic controller still requests the legacy path and still parses its `data` envelope.
- **`TestGetWANStatusUnifiOSNoGateway`** — an empty v2 response yields no error and an empty slice, as the doc comment promises.

`go build`, `go vet` and the full suite pass.

### Known limitation

The classic controllers I have access to run no gateway, so I could not exercise a *populated* legacy response against real hardware. That case is covered by `TestGetWANStatusClassic`, on code this PR does not touch.
