### PR TITLE
fix: don't fail NewProtectClient when the session login fails

### DIFF
--- a/protect.go
+++ b/protect.go
@@ -389,9 +389,17 @@ func NewProtectClient(config *Config) (*Unifi, error) {
 	// GetProtectEventThumbnail authenticate with a session cookie -- so log in when local
 	// credentials are supplied. Never when APIKey is set: Login() uses /status as its login
 	// path in that case, which is the one endpoint this console does not serve.
+	//
+	// A failed login is logged rather than returned. The API key is this constructor's real
+	// credential, and callers routinely pass a username they never chose -- unpoller fills an
+	// unset user with a placeholder -- so failing here would reject a console whose Protect
+	// API answers perfectly. Only the legacy endpoints are lost, and they report their own
+	// errors when called.
 	if config.APIKey == "" && config.User != "" {
 		if err := u.Login(); err != nil {
-			return u, err
+			u.ErrorLog("Protect %s: login as %q failed (%v); continuing with API-key auth. "+
+				"Protect system logs and event thumbnails need a session and will not work.",
+				u.URL, config.User, err)
 		}
 	}
 

--- a/protect_test.go
+++ b/protect_test.go
@@ -542,6 +542,42 @@ func TestNewProtectClientSkipsLoginWithoutUser(t *testing.T) {
 	assert.Equal(t, []string{APIProtectMetaInfoPath}, *requested)
 }
 
+// TestNewProtectClientSurvivesFailedLogin covers the config an operator actually writes for a
+// UNVR: a Protect API key and no local account. unpoller fills the unset username with a
+// placeholder, so a login is attempted with credentials nobody chose and the console answers
+// 403. Failing there would reject a console whose Protect API answers perfectly.
+func TestNewProtectClientSurvivesFailedLogin(t *testing.T) {
+	t.Parallel()
+
+	var logged string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(APILoginPathNew, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	mux.HandleFunc(APIProtectMetaInfoPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"applicationVersion":"7.2.105"}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := NewProtectClient(&Config{
+		URL: srv.URL, User: "unifipoller", Pass: "unifipoller", ProtectAPIKey: "protect-key-abc",
+		DebugLog: discardLogs,
+		ErrorLog: func(msg string, v ...interface{}) { logged = fmt.Sprintf(msg, v...) },
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	a := assert.New(t)
+	a.Equal("7.2.105", c.ServerVersion)
+	// The failure is not silent: it must say what was lost.
+	a.Contains(logged, "login as \"unifipoller\" failed")
+	a.Contains(logged, "will not work")
+}
+
 func TestNewProtectClientRejectsBadConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Follow-up to #240, found by running unpoller against a real UNVR4 rather than only against the fake console in the tests.

## The problem

The config an operator actually writes for a Protect-only console is a Protect API key and **no local account**. unpoller fills an unset username with the placeholder `unifipoller`. That placeholder reaches `Login()`, the console answers `403`, and `NewProtectClient` returned the error — rejecting a console whose Protect Integration API answers every endpoint perfectly:

```
[ERROR] Controller 1 of 1 Auth or Connection Error, retrying: unifi controller:
        (user: unifipoller): https://<unvr>/api/auth/login (status: 403 Forbidden): authentication failed
```

Which is the same class of failure #240 set out to fix, one layer further in.

## The change

The API key is this constructor's real credential. A session is only ever used by the legacy Protect endpoints — `GetProtectLogs` and `GetProtectEventThumbnail` — so a failed login costs those and nothing else, and they report their own errors when called.

So log it loudly, naming exactly what was lost, and carry on:

```
Protect https://<unvr>: login as "unifipoller" failed (...); continuing with API-key auth.
Protect system logs and event thumbnails need a session and will not work.
```

The reachability probe still runs, so `NewProtectClient` returning no error continues to mean "this console really answers Protect".

## Scope

unpoller/unpoller#1068 no longer sends credentials at all when no session could be used, so that caller does not depend on this. It still matters for anyone who passes credentials that turn out to be wrong alongside a working API key — today they lose the whole console rather than just the two legacy endpoints.

`TestNewProtectClientSurvivesFailedLogin` covers it, asserting both that the client is usable and that the failure is not silent.

`go build ./...`, `go test ./...` and `golangci-lint run` (v2.13) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVreutpEATmBjm6PBw9RjQ
