### PR TITLE
feat(wan): attribute enriched WAN configuration to its site

### DIFF
--- a/wan.go
+++ b/wan.go
@@ -11,6 +11,12 @@ type WANEnrichedConfiguration struct {
 	Configuration WANConfiguration `json:"configuration"`
 	Details       WANDetails       `json:"details"`
 	Statistics    WANStatistics    `json:"statistics"`
+
+	// SiteName and SourceName identify where this WAN came from. The API
+	// response carries neither, so GetWANEnrichedConfiguration stamps them
+	// from the site it fetched, the same way GetSiteDPI does.
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // WANConfiguration represents the WAN network configuration.
@@ -203,6 +209,8 @@ func (u *Unifi) GetWANEnrichedConfiguration(sites []*Site) ([]*WANEnrichedConfig
 
 		for _, wan := range raw {
 			if wan != nil {
+				wan.SiteName = site.SiteName
+				wan.SourceName = site.SourceName
 				data = append(data, wan)
 			}
 		}

--- a/wan_attribution_test.go
+++ b/wan_attribution_test.go
@@ -1,0 +1,91 @@
+package unifi // nolint: testpackage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The enriched-configuration endpoint answers with a bare array and carries no
+// site or controller identity of its own — which is exactly why callers cannot
+// tell two controllers apart without help.
+const wanEnrichedBody = `[
+	{"configuration":{"_id":"a1","name":"Internet 1","wan_networkgroup":"WAN"}},
+	{"configuration":{"_id":"a2","name":"Internet 2","wan_networkgroup":"WAN2"}}
+]`
+
+// TestWANEnrichedConfigurationIsAttributed pins the fix: every entry must come
+// back tagged with the site it was fetched for. Without it, a poller watching
+// several controllers emits WAN metrics that are indistinguishable, and any
+// downstream label has to be guessed.
+func TestWANEnrichedConfigurationIsAttributed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(wanEnrichedBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    true,
+	}
+
+	site := &Site{Name: "default", SiteName: "Default (default)", SourceName: srv.URL}
+
+	wans, err := c.GetWANEnrichedConfiguration([]*Site{site})
+	require.NoError(t, err)
+	require.Len(t, wans, 2)
+
+	a := assert.New(t)
+	for _, w := range wans {
+		a.Equal("Default (default)", w.SiteName)
+		a.Equal(srv.URL, w.SourceName)
+	}
+	a.Equal("Internet 1", wans[0].Configuration.Name)
+	a.Equal("WAN2", wans[1].Configuration.WANNetworkgroup)
+}
+
+// TestWANEnrichedConfigurationPerSite covers the multi-site case, the one the
+// fix exists for: each entry keeps the identity of the site it came from
+// instead of inheriting whichever was fetched last.
+func TestWANEnrichedConfigurationPerSite(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/proxy/network/v2/api/site/second/wan/enriched-configuration" {
+			_, _ = w.Write([]byte(`[{"configuration":{"_id":"b1","name":"Fiber","wan_networkgroup":"WAN"}}]`))
+
+			return
+		}
+
+		_, _ = w.Write([]byte(`[{"configuration":{"_id":"a1","name":"Internet 1","wan_networkgroup":"WAN"}}]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    true,
+	}
+
+	wans, err := c.GetWANEnrichedConfiguration([]*Site{
+		{Name: "default", SiteName: "First (default)", SourceName: "https://one"},
+		{Name: "second", SiteName: "Second (second)", SourceName: "https://two"},
+	})
+	require.NoError(t, err)
+	require.Len(t, wans, 2)
+
+	a := assert.New(t)
+	a.Equal("First (default)", wans[0].SiteName)
+	a.Equal("https://one", wans[0].SourceName)
+	a.Equal("Second (second)", wans[1].SiteName)
+	a.Equal("https://two", wans[1].SourceName)
+}


### PR DESCRIPTION
### The problem

`GetWANEnrichedConfiguration` iterates sites and fetches per site, but drops that context on the floor. The returned `WANEnrichedConfiguration` carries no site or controller identity, and the API response has none either — it is a bare array of configurations.

A poller watching several controllers therefore emits WAN metrics that are **indistinguishable from one another**. `promunifi/wan.go` acknowledges this in the exporter itself:

```go
labels := []string{
    cfg.ID,
    cfg.Name,
    cfg.WANNetworkgroup,
    cfg.WANType,
    cfg.WANLoadBalanceType,
    "", // site_name - will be set by caller if available
    "", // source - will be set by caller if available
}
```

Those two placeholders have never been filled, because the caller has nothing to fill them from. `unpoller_wan_*` consequently ships with `site_name=""` and `source=""` on every series, and the only distinguishing label is `wan_id`.

Downstream that leaves one option: hardcode a mapping in the scrape config and hope no second controller ever gains a gateway. When one does, its WAN metrics are silently attributed to the wrong customer — no error, no missing series, just wrong data.

### The fix

Stamp `SiteName` and `SourceName` on each entry as it is appended, from the site being fetched. This is the same thing `GetSiteDPI` does a few lines above in `site.go`:

```go
response.Data[0].SourceName = site.SourceName
response.Data[0].SiteName = site.SiteName
```

Both fields carry `json:"-"`, so nothing changes on the wire, no existing field is touched, and no behaviour changes for callers that ignore them.

### Tests

- **`TestWANEnrichedConfigurationIsAttributed`** — every entry comes back tagged with the site it was fetched for.
- **`TestWANEnrichedConfigurationPerSite`** — the case the fix exists for: with two sites, each entry keeps the identity of the site it came from rather than inheriting whichever was fetched last.

Both are honest about their limits: they **cannot compile** against the previous struct, the fields being new, so this is not a "fails before, passes after" demonstration — it is a new capability with its contract pinned.

`go build`, `go vet` and the full suite pass.

### Follow-up

A companion change in `unpoller/unpoller` will replace the two placeholder labels with `w.SiteName` / `w.SourceName`. It is a two-line change and depends on this one being released; happy to open it as soon as there is a tag.
