### PR TITLE
feat(wan): attribute WAN status to its controller

### DIFF
--- a/wan_status.go
+++ b/wan_status.go
@@ -6,7 +6,12 @@ import "fmt"
 type WANStatus struct {
 	WANInterfaces []WANStatusInterface `json:"wan_interfaces"`
 
-	SiteName string `json:"-"`
+	// SiteName and SourceName identify where this status came from. The API
+	// response carries neither, and a poller watching several controllers has
+	// no other way to tell two of them apart: every UniFi OS console names its
+	// only site "default".
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // WANStatusInterface represents a single WAN interface in the status response.
@@ -54,7 +59,7 @@ func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
 	if len(response.Data) == 0 {
 		u.DebugLog("No WAN status found for site %s", site.Name)
 
-		return &WANStatus{SiteName: site.SiteName}, nil
+		return &WANStatus{SiteName: site.SiteName, SourceName: u.URL}, nil
 	}
 
 	if len(response.Data) > 1 {
@@ -62,6 +67,7 @@ func (u *Unifi) GetWANStatus(site *Site) (*WANStatus, error) {
 	}
 
 	response.Data[0].SiteName = site.SiteName
+	response.Data[0].SourceName = u.URL
 
 	return &response.Data[0], nil
 }
@@ -82,6 +88,7 @@ func (u *Unifi) wanStatusV2(site *Site) (*WANStatus, error) {
 	}
 
 	status.SiteName = site.SiteName
+	status.SourceName = u.URL
 
 	return status, nil
 }

--- a/wan_status_source_test.go
+++ b/wan_status_source_test.go
@@ -1,0 +1,79 @@
+package unifi // nolint: testpackage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const wanStatusSourceBody = `{"wan_interfaces":[
+	{"name":"Internet 1","state":"ACTIVE","wan_networkgroup":"WAN"},
+	{"name":"Cellular","state":"BACKUP","wan_networkgroup":"WAN3"}
+]}`
+
+func wanStatusSourceClient(t *testing.T, body string, unifiOS bool) *Unifi {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, DebugLog: discardLogs, ErrorLog: discardLogs},
+		new:    unifiOS,
+	}
+}
+
+// TestWANStatusCarriesSource is what this change exists for. Every UniFi OS
+// console calls its only site "default", so SiteName alone cannot tell two
+// controllers apart: a poller watching several of them emits WAN status that
+// is indistinguishable, and any downstream attribution has to be guessed.
+func TestWANStatusCarriesSource(t *testing.T) {
+	t.Parallel()
+
+	c := wanStatusSourceClient(t, wanStatusSourceBody, true)
+
+	status, err := c.GetWANStatus(&Site{Name: "default", SiteName: "Default (default)"})
+	require.NoError(t, err)
+	require.Len(t, status.WANInterfaces, 2)
+
+	a := assert.New(t)
+	a.Equal(c.URL, status.SourceName, "SourceName identifies the controller this came from")
+	a.Equal("Default (default)", status.SiteName)
+}
+
+// TestWANStatusCarriesSourceOnLegacy pins the same guarantee on the legacy
+// path, which classic controllers still take.
+func TestWANStatusCarriesSourceOnLegacy(t *testing.T) {
+	t.Parallel()
+
+	c := wanStatusSourceClient(t, `{"data":[{"wan_interfaces":[
+		{"name":"Internet 1","state":"ACTIVE","wan_networkgroup":"WAN"}
+	]}]}`, false)
+
+	status, err := c.GetWANStatus(&Site{Name: "default", SiteName: "Default (default)"})
+	require.NoError(t, err)
+	require.Len(t, status.WANInterfaces, 1)
+
+	assert.Equal(t, c.URL, status.SourceName)
+}
+
+// TestWANStatusCarriesSourceWhenEmpty covers the no-gateway case: the zero
+// value returned there must still say where it came from, otherwise a site
+// without a gateway is the one entry a caller cannot attribute.
+func TestWANStatusCarriesSourceWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	c := wanStatusSourceClient(t, `{}`, true)
+
+	status, err := c.GetWANStatus(&Site{Name: "default", SiteName: "Default (default)"})
+	require.NoError(t, err)
+	assert.Empty(t, status.WANInterfaces)
+	assert.Equal(t, c.URL, status.SourceName)
+}


### PR DESCRIPTION
### The problem

`WANStatus` carries `SiteName` but not `SourceName`. That is not enough to tell two controllers apart, because **every UniFi OS console names its only site `default`** — and it cannot be renamed in the UI. `SiteName` is therefore `"Default (default)"` on all of them.

`promunifi` labels `unpoller_wan_interface_state` with `site_name` and nothing else:

```go
labels := []string{"site_name", "wan_interface", "wan_networkgroup", "state"}
```

So a poller watching several controllers emits WAN status that is **indistinguishable**, and downstream there is nothing left to attribute it with.

### Observed in production

A scrape config had to guess from `site_name`, and filed a UDM's WAN metrics under the wrong customer. No error, no missing series — just wrong data under someone else's name, which is the failure mode that does not get noticed.

The contrast makes the point: `unpoller_device_info`, from the *same controller and the same site*, is attributed correctly, because it carries `source`. The difference is only which labels the exporter has available.

### The fix

Stamp `SourceName` from `u.URL`, the same way `GetSites` already does, in all three return paths:

- the v2 read (`wanStatusV2`)
- the legacy read
- the zero value returned when a site has no gateway

That last one matters: a site without a gateway would otherwise be the single entry a caller cannot attribute.

Both fields carry `json:"-"`, so nothing changes on the wire and no existing field is touched.

This is the same shape as #243, which did exactly this for `WANEnrichedConfiguration`.

### Tests

`wan_status_source_test.go` covers the three paths with an `httptest` server:

- **`TestWANStatusCarriesSource`** — the v2 path used by UniFi OS
- **`TestWANStatusCarriesSourceOnLegacy`** — the legacy path classic controllers still take
- **`TestWANStatusCarriesSourceWhenEmpty`** — the no-gateway case

They cannot compile against the previous struct, the field being new, so this pins a new guarantee rather than demonstrating fails-before/passes-after.

`go build`, `go vet` and the full suite pass.

### Follow-up

A companion change in `unpoller/unpoller` will add `source` to `exportWANStatus`'s label set once this is released — two lines, same as #1071.

The same gap exists on `port_forward` and `integration_network`, which also declare `site_name` without `source`. Happy to follow up on those separately if you'd like; I kept this PR to the one path I could demonstrate end to end.
