### PR TITLE
feat(integration): attribute Integration/v1 entities to their controller

### DIFF
--- a/acl_rules.go
+++ b/acl_rules.go
@@ -29,6 +29,7 @@ func (u *Unifi) GetACLRules(site *IntegrationSite) ([]*ACLRule, error) {
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/firewall_zones.go
+++ b/firewall_zones.go
@@ -29,6 +29,7 @@ func (u *Unifi) GetFirewallZones(site *IntegrationSite) ([]*FirewallZone, error)
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/integration_source_test.go
+++ b/integration_source_test.go
@@ -1,0 +1,80 @@
+package unifi // nolint: testpackage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// integrationSourceClient serves the same one-element payload to every
+// Integration/v1 endpoint. The shape does not matter here: what is under test
+// is the attribution the library stamps on its way out, not the decoding.
+func integrationSourceClient(t *testing.T) *Unifi {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"a1","name":"one"}],"totalCount":1,"count":1}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	return &Unifi{
+		Client: &http.Client{},
+		Config: &Config{
+			URL:      srv.URL,
+			APIKey:   "test-key",
+			DebugLog: discardLogs,
+			ErrorLog: discardLogs,
+		},
+		new: true,
+	}
+}
+
+// TestIntegrationEntitiesCarrySource is what this change exists for. These
+// families carried SiteName alone, and SiteName is "default" on every UniFi OS
+// console — so a poller watching several controllers produced entities that
+// could not be told apart. Each getter must stamp the controller it read from.
+func TestIntegrationEntitiesCarrySource(t *testing.T) {
+	t.Parallel()
+
+	c := integrationSourceClient(t)
+	site := &IntegrationSite{ID: "site-id", Name: "default"}
+
+	t.Run("VPNServer", func(t *testing.T) {
+		got, err := c.GetVPNServers(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+
+	t.Run("SiteToSiteTunnel", func(t *testing.T) {
+		got, err := c.GetSiteToSiteTunnels(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+
+	t.Run("FirewallZone", func(t *testing.T) {
+		got, err := c.GetFirewallZones(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+
+	t.Run("ACLRule", func(t *testing.T) {
+		got, err := c.GetACLRules(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+
+	t.Run("WifiBroadcast", func(t *testing.T) {
+		got, err := c.GetWifiBroadcasts(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+}

--- a/switching.go
+++ b/switching.go
@@ -30,6 +30,7 @@ func (u *Unifi) GetLAGs(site *IntegrationSite) ([]*LAG, error) {
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 
@@ -64,6 +65,7 @@ func (u *Unifi) GetMCLAGDomains(site *IntegrationSite) ([]*MCLAGDomain, error) {
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 
@@ -98,6 +100,7 @@ func (u *Unifi) GetSwitchStacks(site *IntegrationSite) ([]*SwitchStack, error) {
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/types.go
+++ b/types.go
@@ -365,6 +365,7 @@ type WifiBroadcast struct {
 	SecurityConfiguration    WifiBroadcastSecurityConfiguration `json:"securityConfiguration"`
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // FirewallZoneMetadata holds metadata for a firewall zone.
@@ -381,6 +382,7 @@ type FirewallZone struct {
 	NetworkIDs []string             `json:"networkIds"`
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // ACLRule represents a network access control rule from the Integration/v1 API.
@@ -395,6 +397,7 @@ type ACLRule struct {
 	SourceFilter          string   `json:"sourceFilter"`
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // IntegrationNetwork represents a network from the Integration/v1 API.
@@ -432,6 +435,7 @@ type VPNServer struct {
 	Type     string            `json:"type"` // L2TP, OpenVPN, WireGuard, UID
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // SiteToSiteTunnelMetadata holds metadata for a site-to-site tunnel.
@@ -447,6 +451,7 @@ type SiteToSiteTunnel struct {
 	Type     string                   `json:"type"` // IPSec, OpenVPN, WireGuard
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // LAGMember represents a device port membership within a LAG.
@@ -468,6 +473,7 @@ type LAG struct {
 	Type     string      `json:"type"` // local, global
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // MCLAGPeer represents a peer device in an MC-LAG domain.
@@ -491,6 +497,7 @@ type MCLAGDomain struct {
 	Peers    []MCLAGPeer   `json:"peers"`
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // SwitchStackMetadata holds metadata for a switch stack.
@@ -507,6 +514,7 @@ type SwitchStack struct {
 	Name     string              `json:"name"`
 
 	SiteName string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // DNSPolicy represents a DNS policy from the Integration/v1 API.

--- a/vpn_servers.go
+++ b/vpn_servers.go
@@ -30,6 +30,7 @@ func (u *Unifi) GetVPNServers(site *IntegrationSite) ([]*VPNServer, error) {
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 
@@ -64,6 +65,7 @@ func (u *Unifi) GetSiteToSiteTunnels(site *IntegrationSite) ([]*SiteToSiteTunnel
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/wifi_broadcasts.go
+++ b/wifi_broadcasts.go
@@ -29,6 +29,7 @@ func (u *Unifi) GetWifiBroadcasts(site *IntegrationSite) ([]*WifiBroadcast, erro
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 


### PR DESCRIPTION
### The problem

The eight Integration/v1 families carry `SiteName` and nothing else to say where they came from:

`SiteToSiteTunnel` · `VPNServer` · `FirewallZone` · `ACLRule` · `WifiBroadcast` · `LAG` · `MCLAGDomain` · `SwitchStack`

`SiteName` is not enough. **Every UniFi OS console names its only site `default`**, and it cannot be renamed in the UI. A poller watching several controllers therefore produces entities that cannot be told apart, and `promunifi` exports them with a `site_name` label and no `source`:

```go
labels := []string{"site_name", "name", "tunnel_type", "origin"}
```

### Observed in production

Seventeen series from three controllers collapsed onto one customer's name, because the only thing left to attribute them with was a site name every console shares. No error, no missing series — just wrong data under someone else's name, which is the failure mode nobody notices.

**The neighbouring families make the point.** `MagicSiteToSiteVPN` and `PortForward` already carry `SourceName` and are attributed correctly — from the *same controller and the same site*, in the same scrape. The difference is only which fields the getter stamps:

```
unpoller_vpn_mesh_connections_total{... source="https://198.51.100.7:62443"}   ← attributed
unpoller_site_to_site_tunnel_present{site_name="…", name="…", tunnel_type="…"} ← not
```

### The fix

Add `SourceName` to the eight structs and stamp it from `u.URL` in each getter, beside the `SiteName` assignment already there. Same shape as #243 and #244, both merged. `json:"-"` on both fields, so nothing changes on the wire and no existing field is touched.

### Tests

`integration_source_test.go` covers the five getters reachable with a stub server: `GetVPNServers`, `GetSiteToSiteTunnels`, `GetFirewallZones`, `GetACLRules`, `GetWifiBroadcasts`. They cannot compile against the previous structs, the field being new, so this pins a new guarantee rather than demonstrating fails-before/passes-after.

`go build`, `go vet` and the full suite pass.

### Noted while here, deliberately not changed

These getters assign `SiteName = site.Name` — the internal identifier — where the rest of the library assigns `site.SiteName`, the `"Desc (Name)"` form. That is why these families surface as `default` rather than `Default (default)`. Changing it would alter an existing label value for everyone, so it seemed better kept out of an additive change. Happy to send it separately if you want it aligned.

### Follow-up

A companion change in `unpoller/unpoller` will add the `source` label to the corresponding exporters in `pkg/promunifi/integration_network.go`, once this is released — same as #1071 and #1073.
