### PR TITLE
feat(integration): attribute the last four Integration/v1 entities

### DIFF
--- a/dns_policies.go
+++ b/dns_policies.go
@@ -30,6 +30,7 @@ func (u *Unifi) GetDNSPolicies(site *IntegrationSite) ([]*DNSPolicy, error) {
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/hotspot_vouchers.go
+++ b/hotspot_vouchers.go
@@ -29,6 +29,7 @@ func (u *Unifi) GetHotspotVouchers(site *IntegrationSite) ([]*HotspotVoucher, er
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/integration_source_test.go
+++ b/integration_source_test.go
@@ -77,4 +77,32 @@ func TestIntegrationEntitiesCarrySource(t *testing.T) {
 		require.NotEmpty(t, got)
 		assert.Equal(t, c.URL, got[0].SourceName)
 	})
+
+	t.Run("DNSPolicy", func(t *testing.T) {
+		got, err := c.GetDNSPolicies(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+
+	t.Run("RADIUSProfile", func(t *testing.T) {
+		got, err := c.GetRADIUSProfiles(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+
+	t.Run("TrafficMatchingList", func(t *testing.T) {
+		got, err := c.GetTrafficMatchingLists(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
+
+	t.Run("HotspotVoucher", func(t *testing.T) {
+		got, err := c.GetHotspotVouchers(site)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.Equal(t, c.URL, got[0].SourceName)
+	})
 }

--- a/radius_profiles.go
+++ b/radius_profiles.go
@@ -29,6 +29,7 @@ func (u *Unifi) GetRADIUSProfiles(site *IntegrationSite) ([]*RADIUSProfile, erro
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/traffic_matching_lists.go
+++ b/traffic_matching_lists.go
@@ -29,6 +29,7 @@ func (u *Unifi) GetTrafficMatchingLists(site *IntegrationSite) ([]*TrafficMatchi
 
 	for i := range items {
 		items[i].SiteName = site.Name
+		items[i].SourceName = u.URL
 		result[i] = &items[i]
 	}
 

--- a/types.go
+++ b/types.go
@@ -364,7 +364,7 @@ type WifiBroadcast struct {
 	Network                  string                             `json:"network"`
 	SecurityConfiguration    WifiBroadcastSecurityConfiguration `json:"securityConfiguration"`
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -381,7 +381,7 @@ type FirewallZone struct {
 	Name       string               `json:"name"`
 	NetworkIDs []string             `json:"networkIds"`
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -396,7 +396,7 @@ type ACLRule struct {
 	Name                  string   `json:"name"`
 	SourceFilter          string   `json:"sourceFilter"`
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -434,7 +434,7 @@ type VPNServer struct {
 	Name     string            `json:"name"`
 	Type     string            `json:"type"` // L2TP, OpenVPN, WireGuard, UID
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -450,7 +450,7 @@ type SiteToSiteTunnel struct {
 	Name     string                   `json:"name"`
 	Type     string                   `json:"type"` // IPSec, OpenVPN, WireGuard
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -472,7 +472,7 @@ type LAG struct {
 	Metadata LAGMetadata `json:"metadata"`
 	Type     string      `json:"type"` // local, global
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -496,7 +496,7 @@ type MCLAGDomain struct {
 	Name     string        `json:"name"`
 	Peers    []MCLAGPeer   `json:"peers"`
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -513,7 +513,7 @@ type SwitchStack struct {
 	Metadata SwitchStackMetadata `json:"metadata"`
 	Name     string              `json:"name"`
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
 }
 
@@ -524,7 +524,8 @@ type DNSPolicy struct {
 	ID      string `json:"id"`
 	Type    string `json:"type"` // forward-domain, block, allow
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // RADIUSProfileMetadata holds metadata for a RADIUS profile.
@@ -538,7 +539,8 @@ type RADIUSProfile struct {
 	Metadata RADIUSProfileMetadata `json:"metadata"`
 	Name     string                `json:"name"`
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // TrafficMatchingList represents a traffic matching list from the Integration/v1 API.
@@ -548,7 +550,8 @@ type TrafficMatchingList struct {
 	Name string `json:"name"`
 	Type string `json:"type"` // IPv4, IPv6, port
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // HotspotVoucher represents a guest portal voucher from the Integration/v1 API.
@@ -563,7 +566,8 @@ type HotspotVoucher struct {
 	Name                 string  `json:"name"`
 	TimeLimitMinutes     FlexInt `json:"timeLimitMinutes"` // 0 means no time limit
 
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
+	SourceName string `json:"-"`
 }
 
 // DPIApplication represents an entry in the DPI application catalogue.


### PR DESCRIPTION
Follow-up to #246, which gave `SourceName` to eight Integration/v1 entities and missed four.

| entity | `SiteName` | `SourceName` before | after |
|---|---|---|---|
| WifiBroadcast, FirewallZone, ACLRule, VPNServer, SiteToSiteTunnel, LAG, MCLAGDomain, SwitchStack | yes | yes (#246) | yes |
| **DNSPolicy** | yes | **no** | yes |
| **RADIUSProfile** | yes | **no** | yes |
| **TrafficMatchingList** | yes | **no** | yes |
| **HotspotVoucher** | yes | **no** | yes |

Their getters are the same shape as the eight and set `SiteName` in the same loop, so the omission looks like an oversight rather than a decision — mine, in #246. This completes it.

The gap matters for the same reason the other eight did: `SiteName` alone is `default` on every UniFi OS console, so a caller polling several of them cannot tell their entities apart.

## Also: gofmt

#246 added the `SourceName` fields without realigning the field blocks it had widened, so eight struct declarations in `types.go` are unformatted on master:

```
-	SiteName string `json:"-"`
+	SiteName   string `json:"-"`
 	SourceName string `json:"-"`
```

`gofmt -l .` flags `types.go` on master today. This PR runs gofmt on it, which is where the rest of the `types.go` diff comes from. Happy to split that into its own PR if you would rather keep this one to the four entities.

You may want a `gofmt -l` gate in CI — it would have caught this at #246.

## Testing

`go test ./...` — the existing `TestIntegrationEntitiesCarrySource` extended from 5 to 9 subtests, covering each newly attributed entity. It fails without the getter change (the stub server returns a payload with no source of its own, so `SourceName` stays empty).