### PR TITLE
fix(sysinfo): read GetSysinfoSite from the data envelope

### DIFF
--- a/sysinfo.go
+++ b/sysinfo.go
@@ -1,6 +1,12 @@
 package unifi
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNoSysinfoData is returned when the sysinfo endpoint responds without any entries.
+var ErrNoSysinfoData = errors.New("sysinfo endpoint returned no entries")
 
 // Sysinfo holds controller system information and health from GET /proxy/network/api/s/{site}/stat/sysinfo.
 // UniFi OS only. See https://github.com/unpoller/unpoller/issues/927
@@ -39,16 +45,23 @@ type Sysinfo struct {
 func (u *Unifi) GetSysinfoSite(site *Site) (*Sysinfo, error) {
 	path := fmt.Sprintf(APISysinfoPath, site.Name)
 
-	var s Sysinfo
+	var response struct {
+		Data []*Sysinfo `json:"data"`
+	}
 
-	if err := u.GetData(path, &s); err != nil {
+	if err := u.GetData(path, &response); err != nil {
 		return nil, err
 	}
 
+	if len(response.Data) == 0 || response.Data[0] == nil {
+		return nil, fmt.Errorf("%w: site %s", ErrNoSysinfoData, site.Name)
+	}
+
+	s := response.Data[0]
 	s.SiteName = site.SiteName
 	s.SourceName = site.SourceName
 
-	return &s, nil
+	return s, nil
 }
 
 // GetSysinfo returns controller system info for all sites.

--- a/sysinfo_test.go
+++ b/sysinfo_test.go
@@ -1,0 +1,106 @@
+package unifi // nolint: testpackage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The controller wraps sysinfo in the usual {"meta":…,"data":[…]} envelope.
+const sysinfoBody = `{"meta":{"rc":"ok"},"data":[{
+	"timezone":"Etc/UTC",
+	"autobackup":false,
+	"build":"atag_9.9.9_00000",
+	"version":"9.9.9",
+	"previous_version":"9.9.8",
+	"data_retention_days":90,
+	"data_retention_time_in_hours_for_5minutes_scale":24,
+	"update_available":false,
+	"hostname":"unifi",
+	"name":"Console",
+	"inform_port":8080,
+	"https_port":8443,
+	"uptime":123456,
+	"has_webrtc_support":true,
+	"ubnt_device_type":"UCKP",
+	"unsupported_device_count":0,
+	"is_cloud_console":false,
+	"console_display_version":"9.0.0"
+}]}`
+
+const sysinfoEmptyBody = `{"meta":{"rc":"ok"},"data":[]}`
+
+func sysinfoClient(t *testing.T, body string) (*Unifi, *[]string) {
+	t.Helper()
+
+	requested := &[]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requested = append(*requested, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return &Unifi{
+		Client: &http.Client{},
+		Config: &Config{URL: srv.URL, DebugLog: discardLogs, ErrorLog: discardLogs},
+	}, requested
+}
+
+// TestGetSysinfoSite is the regression this change exists for: the response was
+// unmarshalled into a bare Sysinfo, so none of the fields inside the "data"
+// envelope matched. encoding/json reports no error for that, so every caller
+// received a fully zeroed struct and a nil error.
+func TestGetSysinfoSite(t *testing.T) {
+	t.Parallel()
+
+	c, requested := sysinfoClient(t, sysinfoBody)
+
+	s, err := c.GetSysinfoSite(&Site{Name: "default", SiteName: "Default (default)", SourceName: "controller"})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	a := assert.New(t)
+	a.Equal([]string{"/api/s/default/stat/sysinfo"}, *requested)
+	a.Equal("9.9.9", s.Version)
+	a.Equal("atag_9.9.9_00000", s.Build)
+	a.Equal("9.9.8", s.PreviousVer)
+	a.Equal("9.0.0", s.ConsoleVer)
+	a.Equal("UCKP", s.DeviceType)
+	a.Equal("Console", s.Name)
+	a.Equal(90, s.DataRetDays)
+	a.Equal(24, s.DataRet5min)
+	a.Equal(8443, s.HTTPSPort)
+	a.Equal(int64(123456), s.Uptime)
+	a.True(s.HasWebRTC)
+	// SiteName and SourceName carry json:"-" and must be filled in by the caller.
+	a.Equal("Default (default)", s.SiteName)
+	a.Equal("controller", s.SourceName)
+}
+
+// TestGetSysinfoSiteEmpty pins the other half: an empty data array must surface
+// as an error rather than as a zeroed struct that looks like real data.
+func TestGetSysinfoSiteEmpty(t *testing.T) {
+	t.Parallel()
+
+	c, _ := sysinfoClient(t, sysinfoEmptyBody)
+
+	s, err := c.GetSysinfoSite(&Site{Name: "default"})
+	require.ErrorIs(t, err, ErrNoSysinfoData)
+	assert.Nil(t, s)
+}
+
+// TestGetSysinfo walks the per-site loop.
+func TestGetSysinfo(t *testing.T) {
+	t.Parallel()
+
+	c, _ := sysinfoClient(t, sysinfoBody)
+
+	all, err := c.GetSysinfo([]*Site{{Name: "default", SiteName: "Default (default)"}})
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, "9.9.9", all[0].Version)
+}


### PR DESCRIPTION
`GetSysinfoSite` unmarshalled the response into a bare `Sysinfo`, but the controller wraps
it in the usual envelope:

```json
{"meta":{"rc":"ok"},"data":[{"version":"10.x.y", ...}]}
```

Unmarshalling that object into a `Sysinfo` matches no field and returns no error, so
callers received a fully zeroed struct together with `err == nil`. In unpoller that lands
in the success branch of the collector and exports all sixteen `unpoller_controller_*`
metrics with empty labels and zero values, silently — no error, nothing in the debug log.

`populateVersionFromSysinfo` in `unifi.go` already reads the same endpoint through
`struct{ Data []struct{ Version string } }`, so the two callers disagreed about the
response shape. This aligns `GetSysinfoSite` with that, and with `site.go` and every other
list endpoint.

An empty `data` array now returns `ErrNoSysinfoData` instead of a zeroed struct, so a
controller that answers without entries is distinguishable from one that answers with
real data. The collector in unpoller already tolerates an error here — it logs at debug
and continues — so this turns a set of silently wrong metrics into no metrics at all,
which is the safer of the two.

### Tests

`sysinfo_test.go` covers the envelope, the empty-array case and the per-site loop, in the
style of `wan_status_endpoint_test.go`. Without the change, `TestGetSysinfoSite` fails on
the assertion:

```
--- FAIL: TestGetSysinfoSite (0.00s)
    Error: Not equal:
        expected: "9.9.9"
        actual  : ""
```

### Verified against hardware

UCK G2 Plus, UniFi Network 10.x / UniFi OS 5.x. Two builds of unpoller v5.2.3,
identical apart from a `replace` directive pointing at this branch:

```
before  unpoller_controller_info{build="",console_version="",device_type="",version=""} 1
after   unpoller_controller_info{build="atag_10.x.y_NNNNN",console_version="5.x.y",device_type="UCKP",version="10.x.y"} 1
```

The other fifteen controller metrics come to life as well: `data_retention_days` 0 → 90,
`https_port` 0 → 8443, `inform_port` 0 → 8080, `portal_http_port` 0 → 8880,
`uptime_seconds` 0 → a real uptime, `webrtc_support` 0 → 1, and the `hostname` label goes from
the site name to the actual console hostname.

Fixes unpoller/unpoller#1079
